### PR TITLE
#81: fix failing skeleton tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
   ],
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "no-unused-vars": "error"
+    "no-unused-vars": "error",
+    "require-await": "error"
   },
   "env": {
     "node": true,

--- a/packages/api/.lintstagedrc
+++ b/packages/api/.lintstagedrc
@@ -1,5 +1,5 @@
 {
   "*.{js,jsx,ts,tsx}": [
-    "eslint --fix"
+    "eslint"
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,7 @@
   "packageManager": "yarn@3.2.2",
   "scripts": {
     "dev": "NODE_ENV=development node ./scripts/dev.js",
-    "lint": "eslint \"./**/*.{js,ts}\" --max-warnings=0",
+    "lint": "npx eslint \"./**/*.{js,ts}\" --max-warnings=0",
     "prettier": "npx prettier --write .",
     "test": "vitest",
     "test-ui": "vitest --ui",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,7 +30,7 @@
     "@vitest/coverage-c8": "^0.22.1",
     "@vitest/ui": "^0.22.1",
     "typescript": "^4.6.4",
-    "vitest": "^0.22.1"
+    "vitest": "^0.31.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "*",

--- a/packages/web/.lintstagedrc
+++ b/packages/web/.lintstagedrc
@@ -1,5 +1,5 @@
 {
   "*.{js,jsx,ts,tsx}": [
-    "eslint --fix"
+    "eslint"
   ]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,7 +14,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.14",
     "@auth0/auth0-react": "^1.10.2",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
@@ -58,7 +58,7 @@
     "jsdom": "^20.0.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0",
-    "vitest": "^0.22.1"
+    "vitest": "^0.31.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "*",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --port 4000",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
+    "lint": "npx eslint \"./src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "prettier": "npx prettier --write .",
     "test": "vitest",
     "test-ui": "vitest --ui",

--- a/packages/web/src/components/app/components/action-button/action-button.styles.js
+++ b/packages/web/src/components/app/components/action-button/action-button.styles.js
@@ -8,6 +8,7 @@ export const ButtonContainer = styled("div")(
     margin: "auto",
     width: 24,
     height: 24,
+    pointerEvents: "auto",
     cursor: "pointer",
     color: palette.icon,
 

--- a/packages/web/src/components/app/components/action-button/action-button.test.jsx
+++ b/packages/web/src/components/app/components/action-button/action-button.test.jsx
@@ -4,57 +4,53 @@ import Close from "@mui/icons-material/Close";
 import { vi } from "vitest";
 
 describe("action-button", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      onClick: vi.fn(),
-      tooltip: "test tooltip",
-      movie: {
-        id: 123,
-      },
+  beforeEach((context) => {
+    context.onClick = vi.fn();
+    context.tooltip = "test tooltip";
+    context.movie = {
+      id: 123,
     };
   });
 
-  it("should render the button", () => {
+  it("should render the button", ({ onClick, tooltip }) => {
     const { getByTestId, getByLabelText } = render(
-      <ActionButton
-        Icon={Close}
-        onClick={test.onClick}
-        tooltip={test.tooltip}
-      />
+      <ActionButton Icon={Close} onClick={onClick} tooltip={tooltip} />
     );
 
-    expect(getByLabelText(test.tooltip)).toBeInTheDocument();
+    expect(getByLabelText(tooltip)).toBeInTheDocument();
     expect(getByTestId("CloseIcon")).toBeInTheDocument();
   });
 
-  it("should return the movie data when clicked", () => {
+  it("should return the movie data when clicked", ({
+    onClick,
+    tooltip,
+    movie,
+  }) => {
     const { getByLabelText } = render(
       <ActionButton
         Icon={Close}
-        onClick={test.onClick}
-        tooltip={test.tooltip}
-        movie={test.movie}
+        onClick={onClick}
+        tooltip={tooltip}
+        movie={movie}
       />
     );
 
-    fireEvent.click(getByLabelText(test.tooltip));
-    expect(test.onClick).toHaveBeenCalledWith(test.movie);
+    fireEvent.click(getByLabelText(tooltip));
+    expect(onClick).toHaveBeenCalledWith(movie);
   });
 
-  it("should not fire onClick when disabled", () => {
+  it("should not fire onClick when disabled", ({ onClick, tooltip, movie }) => {
     const { getByLabelText } = render(
       <ActionButton
         Icon={Close}
-        onClick={test.onClick}
-        tooltip={test.tooltip}
-        movie={test.movie}
+        onClick={onClick}
+        tooltip={tooltip}
+        movie={movie}
         disabled
       />
     );
 
-    fireEvent.click(getByLabelText(test.tooltip));
-    expect(test.onClick).not.toHaveBeenCalled();
+    fireEvent.click(getByLabelText(tooltip));
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/action-button/action-button.test.jsx
+++ b/packages/web/src/components/app/components/action-button/action-button.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import ActionButton from "./action-button";
 import Close from "@mui/icons-material/Close";
 import { vi } from "vitest";
@@ -19,10 +19,11 @@ describe("action-button", () => {
     expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
   });
 
-  it("should return the movie data when clicked", ({
+  it("should return the movie data when clicked", async ({
     onClick,
     tooltip,
     movie,
+    user,
   }) => {
     render(
       <ActionButton
@@ -33,11 +34,16 @@ describe("action-button", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText(tooltip));
+    await user.click(screen.getByLabelText(tooltip));
     expect(onClick).toHaveBeenCalledWith(movie);
   });
 
-  it("should not fire onClick when disabled", ({ onClick, tooltip, movie }) => {
+  it("should not fire onClick when disabled", async ({
+    onClick,
+    tooltip,
+    movie,
+    user,
+  }) => {
     render(
       <ActionButton
         Icon={Close}
@@ -48,7 +54,7 @@ describe("action-button", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText(tooltip));
+    await user.click(screen.getByLabelText(tooltip));
     expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/action-button/action-button.test.jsx
+++ b/packages/web/src/components/app/components/action-button/action-button.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import ActionButton from "./action-button";
 import Close from "@mui/icons-material/Close";
 import { vi } from "vitest";
@@ -13,12 +13,10 @@ describe("action-button", () => {
   });
 
   it("should render the button", ({ onClick, tooltip }) => {
-    const { getByTestId, getByLabelText } = render(
-      <ActionButton Icon={Close} onClick={onClick} tooltip={tooltip} />
-    );
+    render(<ActionButton Icon={Close} onClick={onClick} tooltip={tooltip} />);
 
-    expect(getByLabelText(tooltip)).toBeInTheDocument();
-    expect(getByTestId("CloseIcon")).toBeInTheDocument();
+    expect(screen.getByLabelText(tooltip)).toBeInTheDocument();
+    expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
   });
 
   it("should return the movie data when clicked", ({
@@ -26,7 +24,7 @@ describe("action-button", () => {
     tooltip,
     movie,
   }) => {
-    const { getByLabelText } = render(
+    render(
       <ActionButton
         Icon={Close}
         onClick={onClick}
@@ -35,12 +33,12 @@ describe("action-button", () => {
       />
     );
 
-    fireEvent.click(getByLabelText(tooltip));
+    fireEvent.click(screen.getByLabelText(tooltip));
     expect(onClick).toHaveBeenCalledWith(movie);
   });
 
   it("should not fire onClick when disabled", ({ onClick, tooltip, movie }) => {
-    const { getByLabelText } = render(
+    render(
       <ActionButton
         Icon={Close}
         onClick={onClick}
@@ -50,7 +48,7 @@ describe("action-button", () => {
       />
     );
 
-    fireEvent.click(getByLabelText(tooltip));
+    fireEvent.click(screen.getByLabelText(tooltip));
     expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.jsx
+++ b/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.jsx
@@ -3,17 +3,13 @@ import CreateListError from "./create-list-error";
 import { vi } from "vitest";
 
 describe("create-list-error", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      reset: vi.fn(),
-    };
+  beforeEach((context) => {
+    context.reset = vi.fn();
   });
 
-  it("should run the reset callback when Try Again is pressed", () => {
-    const { getByRole } = render(<CreateListError reset={test.reset} />);
+  it("should run the reset callback when Try Again is pressed", ({ reset }) => {
+    const { getByRole } = render(<CreateListError reset={reset} />);
     fireEvent.click(getByRole("button", { name: "Try Again" }));
-    expect(test.reset).toHaveBeenCalled();
+    expect(reset).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.jsx
+++ b/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import CreateListError from "./create-list-error";
 import { vi } from "vitest";
 
@@ -7,9 +7,12 @@ describe("create-list-error", () => {
     context.reset = vi.fn();
   });
 
-  it("should run the reset callback when Try Again is pressed", ({ reset }) => {
+  it("should run the reset callback when Try Again is pressed", async ({
+    reset,
+    user,
+  }) => {
     render(<CreateListError reset={reset} />);
-    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    await user.click(screen.getByRole("button", { name: "Try Again" }));
     expect(reset).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.jsx
+++ b/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import CreateListError from "./create-list-error";
 import { vi } from "vitest";
 
@@ -8,8 +8,8 @@ describe("create-list-error", () => {
   });
 
   it("should run the reset callback when Try Again is pressed", ({ reset }) => {
-    const { getByRole } = render(<CreateListError reset={reset} />);
-    fireEvent.click(getByRole("button", { name: "Try Again" }));
+    render(<CreateListError reset={reset} />);
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
     expect(reset).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.jsx
+++ b/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.jsx
@@ -1,8 +1,7 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import CreateListInput from "./create-list-input";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
-import userEvent from "@testing-library/user-event";
 
 describe("create-list-input", () => {
   beforeEach((context) => {
@@ -11,21 +10,19 @@ describe("create-list-input", () => {
 
   it("should callback with the new list name on submit", async ({
     onSubmit,
+    user,
   }) => {
     renderWithProviders(<CreateListInput onSubmit={onSubmit} />);
-    fireEvent.change(screen.getByLabelText("New List Name"), {
-      target: { value: "My List" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Create List" }));
+    await user.type(screen.getByLabelText("New List Name"), "My List");
+    await user.click(screen.getByRole("button", { name: "Create List" }));
     expect(onSubmit).toHaveBeenCalledWith("My List");
   });
 
   it("should display an error if the list name already exists", async ({
     onSubmit,
+    user,
   }) => {
     renderWithProviders(<CreateListInput onSubmit={onSubmit} />);
-
-    const user = userEvent.setup();
 
     await user.type(
       screen.getByRole("textbox", { name: "New List Name" }),
@@ -42,10 +39,11 @@ describe("create-list-input", () => {
 
   it("should display an error if the list name is empty", async ({
     onSubmit,
+    user,
   }) => {
     renderWithProviders(<CreateListInput onSubmit={onSubmit} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Create List" }));
+    await user.click(screen.getByRole("button", { name: "Create List" }));
     expect(
       await screen.findByText("Please enter a name for your list")
     ).toBeInTheDocument();

--- a/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.jsx
+++ b/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.jsx
@@ -2,49 +2,59 @@ import { fireEvent } from "@testing-library/react";
 import CreateListInput from "./create-list-input";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
+import userEvent from "@testing-library/user-event";
 
 describe("create-list-input", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      onSubmit: vi.fn(),
-    };
+  beforeEach((context) => {
+    context.onSubmit = vi.fn();
   });
 
-  it("should callback with the new list name on submit", async () => {
-    const { getByRole, getByLabelText } = await renderWithProviders(
-      <CreateListInput onSubmit={test.onSubmit} />
+  it("should callback with the new list name on submit", async ({
+    onSubmit,
+  }) => {
+    const { getByRole, getByLabelText } = renderWithProviders(
+      <CreateListInput onSubmit={onSubmit} />
     );
     fireEvent.change(getByLabelText("New List Name"), {
       target: { value: "My List" },
     });
     fireEvent.click(getByRole("button", { name: "Create List" }));
-    expect(test.onSubmit).toHaveBeenCalledWith("My List");
+    expect(onSubmit).toHaveBeenCalledWith("My List");
   });
 
-  it("should display an error if the list name already exists", async () => {
-    const { getByRole, getByLabelText, getByText } = await renderWithProviders(
-      <CreateListInput onSubmit={test.onSubmit} />
+  it("should display an error if the list name already exists", async ({
+    onSubmit,
+  }) => {
+    const { getByRole, findByText } = renderWithProviders(
+      <CreateListInput onSubmit={onSubmit} />
     );
 
-    fireEvent.change(getByLabelText("New List Name"), {
-      target: { value: "Saturday Night" },
-    });
+    const user = userEvent.setup();
+
+    await user.type(
+      getByRole("textbox", { name: "New List Name" }),
+      "Saturday Night"
+    );
+
+    await user.click(getByRole("button", { name: "Create List" }));
+
+    expect(
+      await findByText("There is already a list with this name")
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("should display an error if the list name is empty", async ({
+    onSubmit,
+  }) => {
+    const { getByRole, findByText } = renderWithProviders(
+      <CreateListInput onSubmit={onSubmit} />
+    );
+
     fireEvent.click(getByRole("button", { name: "Create List" }));
     expect(
-      getByText("There is already a list with this name")
+      await findByText("Please enter a name for your list")
     ).toBeInTheDocument();
-    expect(test.onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("should display an error if the list name is empty", async () => {
-    const { getByRole, getByText } = await renderWithProviders(
-      <CreateListInput onSubmit={test.onSubmit} />
-    );
-
-    fireEvent.click(getByRole("button", { name: "Create List" }));
-    expect(getByText("Please enter a name for your list")).toBeInTheDocument();
-    expect(test.onSubmit).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.jsx
+++ b/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import CreateListInput from "./create-list-input";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
@@ -12,34 +12,30 @@ describe("create-list-input", () => {
   it("should callback with the new list name on submit", async ({
     onSubmit,
   }) => {
-    const { getByRole, getByLabelText } = renderWithProviders(
-      <CreateListInput onSubmit={onSubmit} />
-    );
-    fireEvent.change(getByLabelText("New List Name"), {
+    renderWithProviders(<CreateListInput onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText("New List Name"), {
       target: { value: "My List" },
     });
-    fireEvent.click(getByRole("button", { name: "Create List" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create List" }));
     expect(onSubmit).toHaveBeenCalledWith("My List");
   });
 
   it("should display an error if the list name already exists", async ({
     onSubmit,
   }) => {
-    const { getByRole, findByText } = renderWithProviders(
-      <CreateListInput onSubmit={onSubmit} />
-    );
+    renderWithProviders(<CreateListInput onSubmit={onSubmit} />);
 
     const user = userEvent.setup();
 
     await user.type(
-      getByRole("textbox", { name: "New List Name" }),
+      screen.getByRole("textbox", { name: "New List Name" }),
       "Saturday Night"
     );
 
-    await user.click(getByRole("button", { name: "Create List" }));
+    await user.click(screen.getByRole("button", { name: "Create List" }));
 
     expect(
-      await findByText("There is already a list with this name")
+      await screen.findByText("There is already a list with this name")
     ).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
@@ -47,13 +43,11 @@ describe("create-list-input", () => {
   it("should display an error if the list name is empty", async ({
     onSubmit,
   }) => {
-    const { getByRole, findByText } = renderWithProviders(
-      <CreateListInput onSubmit={onSubmit} />
-    );
+    renderWithProviders(<CreateListInput onSubmit={onSubmit} />);
 
-    fireEvent.click(getByRole("button", { name: "Create List" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create List" }));
     expect(
-      await findByText("Please enter a name for your list")
+      await screen.findByText("Please enter a name for your list")
     ).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });

--- a/packages/web/src/components/app/components/create/create.jsx
+++ b/packages/web/src/components/app/components/create/create.jsx
@@ -16,30 +16,28 @@ export const Create = () => {
   });
 
   return (
-    <>
-      <EmptyState
-        imgSrc={"images/delorean.png"}
-        quote="&quot;Roads? Where we're going, we don't need roads.&quot;"
-        message={
-          <>
-            The future looks bright.
-            <br />
-            Let&apos;s get started by making a list.
-          </>
-        }
-        content={
-          error ? (
-            <CreateListError reset={reset} />
-          ) : (
-            <CreateListInput
-              onSubmit={(name) => {
-                addList(addListOptions(name));
-              }}
-            />
-          )
-        }
-        inProgress={loading}
-      />
-    </>
+    <EmptyState
+      imgSrc={"images/delorean.png"}
+      quote="&quot;Roads? Where we're going, we don't need roads.&quot;"
+      message={
+        <>
+          The future looks bright.
+          <br />
+          Let&apos;s get started by making a list.
+        </>
+      }
+      content={
+        error ? (
+          <CreateListError reset={reset} />
+        ) : (
+          <CreateListInput
+            onSubmit={(name) => {
+              addList(addListOptions(name));
+            }}
+          />
+        )
+      }
+      inProgress={loading}
+    />
   );
 };

--- a/packages/web/src/components/app/components/create/create.test.jsx
+++ b/packages/web/src/components/app/components/create/create.test.jsx
@@ -24,8 +24,8 @@ describe("create", () => {
     };
   });
 
-  it("should render the create list state", (context) => {
-    useAddList.mockReturnValueOnce(context.addListReturn);
+  it("should render the create list state", ({ addListReturn }) => {
+    useAddList.mockReturnValueOnce(addListReturn);
 
     renderWithProviders(<Create />);
 
@@ -33,8 +33,8 @@ describe("create", () => {
     expect(screen.getByText(/Create List/)).toBeInTheDocument();
   });
 
-  it("should render the error state", (context) => {
-    useAddList.mockReturnValueOnce({ ...context.addListReturn, error: true });
+  it("should render the error state", ({ addListReturn }) => {
+    useAddList.mockReturnValueOnce({ ...addListReturn, error: true });
 
     renderWithProviders(<Create />);
 
@@ -44,8 +44,8 @@ describe("create", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the loading state", (context) => {
-    useAddList.mockReturnValueOnce({ ...context.addListReturn, loading: true });
+  it("should render the loading state", ({ addListReturn }) => {
+    useAddList.mockReturnValueOnce({ ...addListReturn, loading: true });
     renderWithProviders(<Create />);
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });

--- a/packages/web/src/components/app/components/create/create.test.jsx
+++ b/packages/web/src/components/app/components/create/create.test.jsx
@@ -1,0 +1,52 @@
+import { screen } from "@testing-library/dom";
+import { renderWithProviders } from "../../../../utils/render-with-providers";
+import { Create } from "./create";
+import { vi } from "vitest";
+
+const { useAddList } = vi.hoisted(() => ({
+  useAddList: vi.fn(),
+}));
+
+vi.mock("../../../../graphql/mutations", (actual) => {
+  return {
+    ...actual,
+    useAddList,
+  };
+});
+
+describe("create", () => {
+  beforeEach((context) => {
+    context.addListReturn = {
+      addList: vi.fn(),
+      loading: false,
+      error: false,
+      reset: vi.fn(),
+    };
+  });
+
+  it("should render the create list state", (context) => {
+    useAddList.mockReturnValueOnce(context.addListReturn);
+
+    renderWithProviders(<Create />);
+
+    expect(screen.getByText(/New List Name/)).toBeInTheDocument();
+    expect(screen.getByText(/Create List/)).toBeInTheDocument();
+  });
+
+  it("should render the error state", (context) => {
+    useAddList.mockReturnValueOnce({ ...context.addListReturn, error: true });
+
+    renderWithProviders(<Create />);
+
+    expect(screen.getByText(/Sorry/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Try Again" })
+    ).toBeInTheDocument();
+  });
+
+  it("should render the loading state", (context) => {
+    useAddList.mockReturnValueOnce({ ...context.addListReturn, loading: true });
+    renderWithProviders(<Create />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.jsx
+++ b/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.jsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import DeleteDialog from "./delete-dialog";
 import { vi } from "vitest";
 
@@ -16,15 +16,15 @@ describe("delete-dialog", () => {
     expect(screen.getByText(props.content)).toBeInTheDocument();
   });
 
-  it("should call onConfirm", async ({ props }) => {
+  it("should call onConfirm", async ({ props, user }) => {
     render(<DeleteDialog open {...props} />);
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
     expect(props.onConfirm).toHaveBeenCalled();
   });
 
-  it("should call onCancel", ({ props }) => {
+  it("should call onCancel", async ({ props, user }) => {
     render(<DeleteDialog open {...props} />);
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
@@ -35,9 +35,10 @@ describe("delete-dialog", () => {
 
   it("should call onCancel when the backdrop on the dialog is clicked", async ({
     props,
+    user,
   }) => {
     render(<DeleteDialog open {...props} />);
-    fireEvent.click(document.getElementsByClassName("MuiBackdrop-root")[0]);
+    await user.click(document.getElementsByClassName("MuiBackdrop-root")[0]);
     expect(props.onCancel).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.jsx
+++ b/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.jsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import DeleteDialog from "./delete-dialog";
 import { vi } from "vitest";
 
@@ -12,25 +12,25 @@ describe("delete-dialog", () => {
   });
 
   it("should show the content in the dialog", ({ props }) => {
-    const { getByText } = render(<DeleteDialog open {...props} />);
-    expect(getByText(props.content)).toBeInTheDocument();
+    render(<DeleteDialog open {...props} />);
+    expect(screen.getByText(props.content)).toBeInTheDocument();
   });
 
   it("should call onConfirm", async ({ props }) => {
-    const { getByRole } = render(<DeleteDialog open {...props} />);
-    fireEvent.click(getByRole("button", { name: "Delete" }));
+    render(<DeleteDialog open {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(props.onConfirm).toHaveBeenCalled();
   });
 
   it("should call onCancel", ({ props }) => {
-    const { getByRole } = render(<DeleteDialog open {...props} />);
-    fireEvent.click(getByRole("button", { name: "Cancel" }));
+    render(<DeleteDialog open {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
   it("should not show the dialog when open is false", ({ props }) => {
-    const { queryByText } = render(<DeleteDialog open={false} {...props} />);
-    expect(queryByText(props.content)).not.toBeInTheDocument();
+    render(<DeleteDialog open={false} {...props} />);
+    expect(screen.queryByText(props.content)).not.toBeInTheDocument();
   });
 
   it("should call onCancel when the backdrop on the dialog is clicked", async ({

--- a/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.jsx
+++ b/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.jsx
@@ -3,39 +3,39 @@ import DeleteDialog from "./delete-dialog";
 import { vi } from "vitest";
 
 describe("delete-dialog", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       content: "This movie will be removed",
       onConfirm: vi.fn(),
       onCancel: vi.fn(),
     };
   });
 
-  it("should show the content in the dialog", () => {
+  it("should show the content in the dialog", ({ props }) => {
     const { getByText } = render(<DeleteDialog open {...props} />);
     expect(getByText(props.content)).toBeInTheDocument();
   });
 
-  it("should call onConfirm", async () => {
+  it("should call onConfirm", async ({ props }) => {
     const { getByRole } = render(<DeleteDialog open {...props} />);
     fireEvent.click(getByRole("button", { name: "Delete" }));
     expect(props.onConfirm).toHaveBeenCalled();
   });
 
-  it("should call onCancel", () => {
+  it("should call onCancel", ({ props }) => {
     const { getByRole } = render(<DeleteDialog open {...props} />);
     fireEvent.click(getByRole("button", { name: "Cancel" }));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
-  it("should not show the dialog when open is false", () => {
+  it("should not show the dialog when open is false", ({ props }) => {
     const { queryByText } = render(<DeleteDialog open={false} {...props} />);
     expect(queryByText(props.content)).not.toBeInTheDocument();
   });
 
-  it("should call onCancel when the backdrop on the dialog is clicked", async () => {
+  it("should call onCancel when the backdrop on the dialog is clicked", async ({
+    props,
+  }) => {
     render(<DeleteDialog open {...props} />);
     fireEvent.click(document.getElementsByClassName("MuiBackdrop-root")[0]);
     expect(props.onCancel).toHaveBeenCalled();

--- a/packages/web/src/components/app/components/empty-state/empty-state.test.jsx
+++ b/packages/web/src/components/app/components/empty-state/empty-state.test.jsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import EmptyState from "./empty-state";
 
 describe("empty-state", () => {
@@ -12,33 +12,35 @@ describe("empty-state", () => {
   });
 
   it("should render the image", ({ props }) => {
-    const { getByAltText } = render(<EmptyState {...props} />);
-    expect(getByAltText("Empty image")).toBeInTheDocument();
-    expect(getByAltText("Empty image").getAttribute("src")).toBe(props.imgSrc);
+    render(<EmptyState {...props} />);
+    expect(screen.getByAltText("Empty image")).toBeInTheDocument();
+    expect(screen.getByAltText("Empty image").getAttribute("src")).toBe(
+      props.imgSrc
+    );
   });
 
   it("should render the quote when provided", ({ props }) => {
-    const { getByText } = render(<EmptyState {...props} />);
-    expect(getByText(props.quote)).toBeInTheDocument();
+    render(<EmptyState {...props} />);
+    expect(screen.getByText(props.quote)).toBeInTheDocument();
   });
 
   it("should not render the quote if omitted", ({ props }) => {
-    const { queryByText } = render(<EmptyState />);
-    expect(queryByText(props.quote)).not.toBeInTheDocument();
+    render(<EmptyState />);
+    expect(screen.queryByText(props.quote)).not.toBeInTheDocument();
   });
 
   it("should render the message", ({ props }) => {
-    const { getByText } = render(<EmptyState {...props} />);
-    expect(getByText(props.message)).toBeInTheDocument();
+    render(<EmptyState {...props} />);
+    expect(screen.getByText(props.message)).toBeInTheDocument();
   });
 
   it("should render the content when not in progress", ({ props }) => {
-    const { getByText } = render(<EmptyState {...props} />);
-    expect(getByText(props.content)).toBeInTheDocument();
+    render(<EmptyState {...props} />);
+    expect(screen.getByText(props.content)).toBeInTheDocument();
   });
 
   it("should render the loading indicator when in progress", ({ props }) => {
-    const { getByRole } = render(<EmptyState {...props} inProgress />);
-    expect(getByRole("progressbar")).toBeInTheDocument();
+    render(<EmptyState {...props} inProgress />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/empty-state/empty-state.test.jsx
+++ b/packages/web/src/components/app/components/empty-state/empty-state.test.jsx
@@ -2,10 +2,8 @@ import { render } from "@testing-library/react";
 import EmptyState from "./empty-state";
 
 describe("empty-state", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       imgSrc: "/public/images/logo.png",
       quote: "A witty quote",
       message: "This is the message",
@@ -13,33 +11,33 @@ describe("empty-state", () => {
     };
   });
 
-  it("should render the image", () => {
+  it("should render the image", ({ props }) => {
     const { getByAltText } = render(<EmptyState {...props} />);
     expect(getByAltText("Empty image")).toBeInTheDocument();
     expect(getByAltText("Empty image").getAttribute("src")).toBe(props.imgSrc);
   });
 
-  it("should render the quote when provided", () => {
+  it("should render the quote when provided", ({ props }) => {
     const { getByText } = render(<EmptyState {...props} />);
     expect(getByText(props.quote)).toBeInTheDocument();
   });
 
-  it("should not render the quote if omitted", () => {
+  it("should not render the quote if omitted", ({ props }) => {
     const { queryByText } = render(<EmptyState />);
     expect(queryByText(props.quote)).not.toBeInTheDocument();
   });
 
-  it("should render the message", () => {
+  it("should render the message", ({ props }) => {
     const { getByText } = render(<EmptyState {...props} />);
     expect(getByText(props.message)).toBeInTheDocument();
   });
 
-  it("should render the content when not in progress", () => {
+  it("should render the content when not in progress", ({ props }) => {
     const { getByText } = render(<EmptyState {...props} />);
     expect(getByText(props.content)).toBeInTheDocument();
   });
 
-  it("should render the loading indicator when in progress", () => {
+  it("should render the loading indicator when in progress", ({ props }) => {
     const { getByRole } = render(<EmptyState {...props} inProgress />);
     expect(getByRole("progressbar")).toBeInTheDocument();
   });

--- a/packages/web/src/components/app/components/error-dialog/error-dialog.test.jsx
+++ b/packages/web/src/components/app/components/error-dialog/error-dialog.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import ErrorDialog from "./error-dialog";
 import { vi } from "vitest";
 
@@ -21,11 +21,12 @@ describe("error-dialog", () => {
     expect(screen.queryByText(props.content)).not.toBeInTheDocument();
   });
 
-  it("should call onConfirm when the dialog Ok button is pressed", ({
+  it("should call onConfirm when the dialog Ok button is pressed", async ({
     props,
+    user,
   }) => {
     render(<ErrorDialog {...props} />);
-    fireEvent.click(screen.getByRole("button", { name: "Ok" }));
+    await user.click(screen.getByRole("button", { name: "Ok" }));
     expect(props.onConfirm).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/error-dialog/error-dialog.test.jsx
+++ b/packages/web/src/components/app/components/error-dialog/error-dialog.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import ErrorDialog from "./error-dialog";
 import { vi } from "vitest";
 
@@ -12,20 +12,20 @@ describe("error-dialog", () => {
   });
 
   it("should display the content when open", ({ props }) => {
-    const { getByText } = render(<ErrorDialog {...props} />);
-    expect(getByText(props.content)).toBeInTheDocument();
+    render(<ErrorDialog {...props} />);
+    expect(screen.getByText(props.content)).toBeInTheDocument();
   });
 
   it("should not display the content when closed", ({ props }) => {
-    const { queryByText } = render(<ErrorDialog {...props} open={false} />);
-    expect(queryByText(props.content)).not.toBeInTheDocument();
+    render(<ErrorDialog {...props} open={false} />);
+    expect(screen.queryByText(props.content)).not.toBeInTheDocument();
   });
 
   it("should call onConfirm when the dialog Ok button is pressed", ({
     props,
   }) => {
-    const { getByRole } = render(<ErrorDialog {...props} />);
-    fireEvent.click(getByRole("button", { name: "Ok" }));
+    render(<ErrorDialog {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ok" }));
     expect(props.onConfirm).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/error-dialog/error-dialog.test.jsx
+++ b/packages/web/src/components/app/components/error-dialog/error-dialog.test.jsx
@@ -3,27 +3,27 @@ import ErrorDialog from "./error-dialog";
 import { vi } from "vitest";
 
 describe("error-dialog", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       open: true,
       content: "This is the error content",
       onConfirm: vi.fn(),
     };
   });
 
-  it("should display the content when open", () => {
+  it("should display the content when open", ({ props }) => {
     const { getByText } = render(<ErrorDialog {...props} />);
     expect(getByText(props.content)).toBeInTheDocument();
   });
 
-  it("should not display the content when closed", () => {
+  it("should not display the content when closed", ({ props }) => {
     const { queryByText } = render(<ErrorDialog {...props} open={false} />);
     expect(queryByText(props.content)).not.toBeInTheDocument();
   });
 
-  it("should call onConfirm when the dialog Ok button is pressed", () => {
+  it("should call onConfirm when the dialog Ok button is pressed", ({
+    props,
+  }) => {
     const { getByRole } = render(<ErrorDialog {...props} />);
     fireEvent.click(getByRole("button", { name: "Ok" }));
     expect(props.onConfirm).toHaveBeenCalled();

--- a/packages/web/src/components/app/components/five-star-rating/five-star-rating.test.jsx
+++ b/packages/web/src/components/app/components/five-star-rating/five-star-rating.test.jsx
@@ -1,88 +1,88 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import FiveStarRating from "./five-star-rating";
 
 describe("five-star-rating", () => {
   it("should render the correct stars for the given ratings", () => {
-    const { getAllByAltText } = render(<FiveStarRating stars={3.5} />);
-    expect(getAllByAltText("star-full")).toHaveLength(3);
-    expect(getAllByAltText("star-half")).toHaveLength(1);
-    expect(getAllByAltText("star-outline")).toHaveLength(1);
+    render(<FiveStarRating stars={3.5} />);
+    expect(screen.getAllByAltText("star-full")).toHaveLength(3);
+    expect(screen.getAllByAltText("star-half")).toHaveLength(1);
+    expect(screen.getAllByAltText("star-outline")).toHaveLength(1);
   });
 
   it("should render zero stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={0} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(0);
-    expect(queryAllByAltText("star-half")).toHaveLength(0);
-    expect(queryAllByAltText("star-outline")).toHaveLength(5);
+    render(<FiveStarRating stars={0} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(5);
   });
 
   it("should render a half star", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={0.5} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(0);
-    expect(queryAllByAltText("star-half")).toHaveLength(1);
-    expect(queryAllByAltText("star-outline")).toHaveLength(4);
+    render(<FiveStarRating stars={0.5} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(4);
   });
 
   it("should render one star", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={1} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(1);
-    expect(queryAllByAltText("star-half")).toHaveLength(0);
-    expect(queryAllByAltText("star-outline")).toHaveLength(4);
+    render(<FiveStarRating stars={1} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(4);
   });
 
   it("should render one and a half stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={1.5} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(1);
-    expect(queryAllByAltText("star-half")).toHaveLength(1);
-    expect(queryAllByAltText("star-outline")).toHaveLength(3);
+    render(<FiveStarRating stars={1.5} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(3);
   });
 
   it("should render two stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={2} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(2);
-    expect(queryAllByAltText("star-half")).toHaveLength(0);
-    expect(queryAllByAltText("star-outline")).toHaveLength(3);
+    render(<FiveStarRating stars={2} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(2);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(3);
   });
 
   it("should render two and a half stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={2.5} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(2);
-    expect(queryAllByAltText("star-half")).toHaveLength(1);
-    expect(queryAllByAltText("star-outline")).toHaveLength(2);
+    render(<FiveStarRating stars={2.5} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(2);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(2);
   });
 
   it("should render three stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={3} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(3);
-    expect(queryAllByAltText("star-half")).toHaveLength(0);
-    expect(queryAllByAltText("star-outline")).toHaveLength(2);
+    render(<FiveStarRating stars={3} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(3);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(2);
   });
 
   it("should render three and a half stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={3.5} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(3);
-    expect(queryAllByAltText("star-half")).toHaveLength(1);
-    expect(queryAllByAltText("star-outline")).toHaveLength(1);
+    render(<FiveStarRating stars={3.5} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(3);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(1);
   });
 
   it("should render four stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={4} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(4);
-    expect(queryAllByAltText("star-half")).toHaveLength(0);
-    expect(queryAllByAltText("star-outline")).toHaveLength(1);
+    render(<FiveStarRating stars={4} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(4);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(1);
   });
 
   it("should render four and a half stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={4.5} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(4);
-    expect(queryAllByAltText("star-half")).toHaveLength(1);
-    expect(queryAllByAltText("star-outline")).toHaveLength(0);
+    render(<FiveStarRating stars={4.5} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(4);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(1);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(0);
   });
 
   it("should render five stars", () => {
-    const { queryAllByAltText } = render(<FiveStarRating stars={5} />);
-    expect(queryAllByAltText("star-full")).toHaveLength(5);
-    expect(queryAllByAltText("star-half")).toHaveLength(0);
-    expect(queryAllByAltText("star-outline")).toHaveLength(0);
+    render(<FiveStarRating stars={5} />);
+    expect(screen.queryAllByAltText("star-full")).toHaveLength(5);
+    expect(screen.queryAllByAltText("star-half")).toHaveLength(0);
+    expect(screen.queryAllByAltText("star-outline")).toHaveLength(0);
   });
 });

--- a/packages/web/src/components/app/components/footer/footer.test.jsx
+++ b/packages/web/src/components/app/components/footer/footer.test.jsx
@@ -3,7 +3,7 @@ import Footer from "./footer";
 
 describe("footer", () => {
   it("should render the nav with the correct urls", async () => {
-    const { getByRole } = await renderWithProviders(<Footer />);
+    const { getByRole } = renderWithProviders(<Footer />);
     expect(getByRole("link", { name: "Movies" })).toHaveAttribute("href", "/");
     expect(getByRole("link", { name: "Watched" })).toHaveAttribute(
       "href",

--- a/packages/web/src/components/app/components/footer/footer.test.jsx
+++ b/packages/web/src/components/app/components/footer/footer.test.jsx
@@ -3,7 +3,7 @@ import { renderWithProviders } from "../../../../utils/render-with-providers";
 import Footer from "./footer";
 
 describe("footer", () => {
-  it("should render the nav with the correct urls", async () => {
+  it("should render the nav with the correct urls", () => {
     renderWithProviders(<Footer />);
     expect(screen.getByRole("link", { name: "Movies" })).toHaveAttribute(
       "href",

--- a/packages/web/src/components/app/components/footer/footer.test.jsx
+++ b/packages/web/src/components/app/components/footer/footer.test.jsx
@@ -1,11 +1,15 @@
+import { screen } from "@testing-library/dom";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import Footer from "./footer";
 
 describe("footer", () => {
   it("should render the nav with the correct urls", async () => {
-    const { getByRole } = renderWithProviders(<Footer />);
-    expect(getByRole("link", { name: "Movies" })).toHaveAttribute("href", "/");
-    expect(getByRole("link", { name: "Watched" })).toHaveAttribute(
+    renderWithProviders(<Footer />);
+    expect(screen.getByRole("link", { name: "Movies" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(screen.getByRole("link", { name: "Watched" })).toHaveAttribute(
       "href",
       "/watched"
     );

--- a/packages/web/src/components/app/components/full-detail/components/footer/footer.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/footer/footer.test.jsx
@@ -3,16 +3,12 @@ import Footer from "./footer";
 import { vi } from "vitest";
 
 describe("full detail footer", () => {
-  let test;
-
   const { open } = window;
 
-  beforeEach(() => {
-    test = {
-      movie: {
-        id: 123,
-        title: "TheNameOfAFilm",
-      },
+  beforeEach((context) => {
+    context.movie = {
+      id: 123,
+      title: "TheNameOfAFilm",
     };
 
     // Delete the existing
@@ -25,26 +21,30 @@ describe("full detail footer", () => {
     window.open = open;
   });
 
-  it("should render the footer action images", () => {
-    const { getByAltText } = render(<Footer movie={test.movie} />);
+  it("should render the footer action images", ({ movie }) => {
+    const { getByAltText } = render(<Footer movie={movie} />);
     expect(getByAltText("Search IMDB")).toBeInTheDocument();
     expect(getByAltText("Search TMDB")).toBeInTheDocument();
     expect(getByAltText("Search Common Sense Media")).toBeInTheDocument();
   });
 
-  it("should open IMDB with title when clicked when no imdbID is provided", () => {
-    const { getByAltText } = render(<Footer movie={test.movie} />);
+  it("should open IMDB with title when clicked when no imdbID is provided", ({
+    movie,
+  }) => {
+    const { getByAltText } = render(<Footer movie={movie} />);
     fireEvent.click(getByAltText("Search IMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
-      expect.stringMatching(new RegExp(`www.imdb.com.*${test.movie.title}`)),
+      expect.stringMatching(new RegExp(`www.imdb.com.*${movie.title}`)),
       "movieInfo"
     );
   });
 
-  it("should open IMDB with imdbID and ignore title when both are provided", () => {
+  it("should open IMDB with imdbID and ignore title when both are provided", ({
+    movie,
+  }) => {
     const { getByAltText } = render(
-      <Footer movie={{ ...test.movie, imdbID: "t12345" }} />
+      <Footer movie={{ ...movie, imdbID: "t12345" }} />
     );
     fireEvent.click(getByAltText("Search IMDB"));
     expect(window.open).toHaveBeenCalledWith(
@@ -54,25 +54,23 @@ describe("full detail footer", () => {
     );
   });
 
-  it("should open TMDB when clicked", () => {
-    const { getByAltText } = render(<Footer movie={test.movie} />);
+  it("should open TMDB when clicked", ({ movie }) => {
+    const { getByAltText } = render(<Footer movie={movie} />);
     fireEvent.click(getByAltText("Search TMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
-      expect.stringMatching(
-        new RegExp(`www.themoviedb.org.*${test.movie.title}`)
-      ),
+      expect.stringMatching(new RegExp(`www.themoviedb.org.*${movie.title}`)),
       "movieInfo"
     );
   });
 
-  it("should open Common Sense Media when clicked", () => {
-    const { getByAltText } = render(<Footer movie={test.movie} />);
+  it("should open Common Sense Media when clicked", ({ movie }) => {
+    const { getByAltText } = render(<Footer movie={movie} />);
     fireEvent.click(getByAltText("Search Common Sense Media"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(
-        new RegExp(`www.commonsensemedia.org.*${test.movie.title}`)
+        new RegExp(`www.commonsensemedia.org.*${movie.title}`)
       ),
       "movieInfo"
     );

--- a/packages/web/src/components/app/components/full-detail/components/footer/footer.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/footer/footer.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Footer from "./footer";
 import { vi } from "vitest";
 
@@ -30,11 +30,12 @@ describe("full detail footer", () => {
     ).toBeInTheDocument();
   });
 
-  it("should open IMDB with title when clicked when no imdbID is provided", ({
+  it("should open IMDB with title when clicked when no imdbID is provided", async ({
     movie,
+    user,
   }) => {
     render(<Footer movie={movie} />);
-    fireEvent.click(screen.getByAltText("Search IMDB"));
+    await user.click(screen.getByAltText("Search IMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(new RegExp(`www.imdb.com.*${movie.title}`)),
@@ -42,11 +43,12 @@ describe("full detail footer", () => {
     );
   });
 
-  it("should open IMDB with imdbID and ignore title when both are provided", ({
+  it("should open IMDB with imdbID and ignore title when both are provided", async ({
     movie,
+    user,
   }) => {
     render(<Footer movie={{ ...movie, imdbID: "t12345" }} />);
-    fireEvent.click(screen.getByAltText("Search IMDB"));
+    await user.click(screen.getByAltText("Search IMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(new RegExp(`www.imdb.com.*t12345`)),
@@ -54,9 +56,9 @@ describe("full detail footer", () => {
     );
   });
 
-  it("should open TMDB when clicked", ({ movie }) => {
+  it("should open TMDB when clicked", async ({ movie, user }) => {
     render(<Footer movie={movie} />);
-    fireEvent.click(screen.getByAltText("Search TMDB"));
+    await user.click(screen.getByAltText("Search TMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(new RegExp(`www.themoviedb.org.*${movie.title}`)),
@@ -64,9 +66,9 @@ describe("full detail footer", () => {
     );
   });
 
-  it("should open Common Sense Media when clicked", ({ movie }) => {
+  it("should open Common Sense Media when clicked", async ({ movie, user }) => {
     render(<Footer movie={movie} />);
-    fireEvent.click(screen.getByAltText("Search Common Sense Media"));
+    await user.click(screen.getByAltText("Search Common Sense Media"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(

--- a/packages/web/src/components/app/components/full-detail/components/footer/footer.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/footer/footer.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Footer from "./footer";
 import { vi } from "vitest";
 
@@ -22,17 +22,19 @@ describe("full detail footer", () => {
   });
 
   it("should render the footer action images", ({ movie }) => {
-    const { getByAltText } = render(<Footer movie={movie} />);
-    expect(getByAltText("Search IMDB")).toBeInTheDocument();
-    expect(getByAltText("Search TMDB")).toBeInTheDocument();
-    expect(getByAltText("Search Common Sense Media")).toBeInTheDocument();
+    render(<Footer movie={movie} />);
+    expect(screen.getByAltText("Search IMDB")).toBeInTheDocument();
+    expect(screen.getByAltText("Search TMDB")).toBeInTheDocument();
+    expect(
+      screen.getByAltText("Search Common Sense Media")
+    ).toBeInTheDocument();
   });
 
   it("should open IMDB with title when clicked when no imdbID is provided", ({
     movie,
   }) => {
-    const { getByAltText } = render(<Footer movie={movie} />);
-    fireEvent.click(getByAltText("Search IMDB"));
+    render(<Footer movie={movie} />);
+    fireEvent.click(screen.getByAltText("Search IMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(new RegExp(`www.imdb.com.*${movie.title}`)),
@@ -43,10 +45,8 @@ describe("full detail footer", () => {
   it("should open IMDB with imdbID and ignore title when both are provided", ({
     movie,
   }) => {
-    const { getByAltText } = render(
-      <Footer movie={{ ...movie, imdbID: "t12345" }} />
-    );
-    fireEvent.click(getByAltText("Search IMDB"));
+    render(<Footer movie={{ ...movie, imdbID: "t12345" }} />);
+    fireEvent.click(screen.getByAltText("Search IMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(new RegExp(`www.imdb.com.*t12345`)),
@@ -55,8 +55,8 @@ describe("full detail footer", () => {
   });
 
   it("should open TMDB when clicked", ({ movie }) => {
-    const { getByAltText } = render(<Footer movie={movie} />);
-    fireEvent.click(getByAltText("Search TMDB"));
+    render(<Footer movie={movie} />);
+    fireEvent.click(screen.getByAltText("Search TMDB"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(new RegExp(`www.themoviedb.org.*${movie.title}`)),
@@ -65,8 +65,8 @@ describe("full detail footer", () => {
   });
 
   it("should open Common Sense Media when clicked", ({ movie }) => {
-    const { getByAltText } = render(<Footer movie={movie} />);
-    fireEvent.click(getByAltText("Search Common Sense Media"));
+    render(<Footer movie={movie} />);
+    fireEvent.click(screen.getByAltText("Search Common Sense Media"));
     expect(window.open).toHaveBeenCalledWith(
       // Without replicating the entire URL, this should ensure the URL has the right domain and the movie title
       expect.stringMatching(

--- a/packages/web/src/components/app/components/full-detail/components/rated/rated.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/rated/rated.test.jsx
@@ -1,14 +1,14 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Rated from "./rated";
 
 describe("rated", () => {
   it("should display the rating", () => {
-    const { getByText } = render(<Rated rated="PG-13" />);
-    expect(getByText("PG-13")).toBeInTheDocument();
+    render(<Rated rated="PG-13" />);
+    expect(screen.getByText("PG-13")).toBeInTheDocument();
   });
 
   it("should not render anything whne rated is null", () => {
-    const { queryByTestId } = render(<Rated rated={null} />);
-    expect(queryByTestId("rated")).not.toBeInTheDocument();
+    render(<Rated rated={null} />);
+    expect(screen.queryByTestId("rated")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.test.jsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import ScrollArea from "./scroll-area";
 
 const enableScrollScenario = (scrollTop, scrollHeight) => {

--- a/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.test.jsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import ScrollArea from "./scroll-area";
 
 const enableScrollScenario = (scrollTop, scrollHeight) => {

--- a/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.test.jsx
@@ -18,13 +18,9 @@ const enableScrollScenario = (scrollTop, scrollHeight) => {
   });
 };
 
-const enableOverflowTop = () => enableScrollScenario(20, 0);
-const enableOverflowBottom = () => enableScrollScenario(0, 200);
-const enableOverflowBoth = () => enableScrollScenario(20, 200);
-
 describe("scroll-area", () => {
   it("should enable the scroll affordance on the top when overflowed above", async () => {
-    enableOverflowTop();
+    enableScrollScenario(20, 0);
 
     const { container } = render(
       <ScrollArea text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
@@ -44,7 +40,7 @@ describe("scroll-area", () => {
   });
 
   it("should enable the scroll affordance on the bottom when overflowed below", async () => {
-    enableOverflowBottom();
+    enableScrollScenario(0, 200);
 
     const { container } = render(
       <ScrollArea text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
@@ -64,7 +60,7 @@ describe("scroll-area", () => {
   });
 
   it("should enable the scroll affordance on both the top and bottom when overflowed in both directions", async () => {
-    enableOverflowBoth();
+    enableScrollScenario(20, 200);
 
     const { container } = render(
       <ScrollArea text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />

--- a/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { createMatchMedia } from "../../../../../../utils/create-match-media";
 import { StarRatingLayout } from "./star-rating-layout";
 
@@ -27,6 +27,7 @@ describe("star-rating-layout", () => {
 
   it("should toggle the ratings breakdown with mouseEnter and mouseLeave when mobile", async ({
     ratings,
+    user,
   }) => {
     render(<StarRatingLayout ratings={ratings} />);
 
@@ -38,7 +39,7 @@ describe("star-rating-layout", () => {
       opacity: "-0.25",
     });
 
-    fireEvent.mouseEnter(starRatingLayout);
+    await user.hover(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).toHaveStyle({
@@ -48,7 +49,7 @@ describe("star-rating-layout", () => {
       { timeout: 5000 }
     );
 
-    fireEvent.mouseLeave(starRatingLayout);
+    await user.unhover(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).not.toHaveStyle({
@@ -61,6 +62,7 @@ describe("star-rating-layout", () => {
 
   it("should toggle the ratings breakdown with click when mobile", async ({
     ratings,
+    user,
   }) => {
     render(<StarRatingLayout ratings={ratings} />);
 
@@ -72,7 +74,7 @@ describe("star-rating-layout", () => {
       opacity: "-0.25",
     });
 
-    fireEvent.click(starRatingLayout);
+    await user.click(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).toHaveStyle({
@@ -82,7 +84,7 @@ describe("star-rating-layout", () => {
       { timeout: 5000 }
     );
 
-    fireEvent.click(starRatingLayout);
+    await user.click(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).not.toHaveStyle({
@@ -95,6 +97,7 @@ describe("star-rating-layout", () => {
 
   it("should toggle the ratings breakdown with mouseEnter and mouseLeave when above mobile", async ({
     ratings,
+    user,
   }) => {
     // Mock a 660 pixel width
     window.matchMedia = createMatchMedia(660);
@@ -109,7 +112,7 @@ describe("star-rating-layout", () => {
       opacity: "-0.25",
     });
 
-    fireEvent.mouseEnter(starRatingLayout);
+    await user.hover(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).toHaveStyle({
@@ -119,7 +122,7 @@ describe("star-rating-layout", () => {
       { timeout: 5000 }
     );
 
-    fireEvent.mouseLeave(starRatingLayout);
+    await user.unhover(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).toHaveStyle({
@@ -132,6 +135,7 @@ describe("star-rating-layout", () => {
 
   it("should toggle the ratings breakdown with click when above mobile", async ({
     ratings,
+    user,
   }) => {
     // Mock a 660 pixel width
     window.matchMedia = createMatchMedia(660);
@@ -146,7 +150,7 @@ describe("star-rating-layout", () => {
       opacity: "-0.25",
     });
 
-    fireEvent.click(starRatingLayout);
+    await user.click(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).toHaveStyle({
@@ -156,7 +160,7 @@ describe("star-rating-layout", () => {
       { timeout: 5000 }
     );
 
-    fireEvent.click(starRatingLayout);
+    await user.click(starRatingLayout);
     await waitFor(
       () =>
         expect(ratingsBreakdown).toHaveStyle({

--- a/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.jsx
@@ -3,22 +3,20 @@ import { createMatchMedia } from "../../../../../../utils/create-match-media";
 import { StarRatingLayout } from "./star-rating-layout";
 
 describe("star-rating-layout", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      ratings: {
-        id: "tt2463208",
-        IMDB: "67%",
-        ROTTEN_TOMATOES: "68%",
-        METACRITIC: "55%",
-      },
+  beforeEach((context) => {
+    context.ratings = {
+      id: "tt2463208",
+      IMDB: "67%",
+      ROTTEN_TOMATOES: "68%",
+      METACRITIC: "55%",
     };
   });
 
-  it("should render the five-star rating and ratings breakdown", () => {
+  it("should render the five-star rating and ratings breakdown", ({
+    ratings,
+  }) => {
     const { getAllByAltText, getByAltText, getByText } = render(
-      <StarRatingLayout ratings={test.ratings} />
+      <StarRatingLayout ratings={ratings} />
     );
     expect(getAllByAltText(/star-/)).toHaveLength(5);
     expect(getByAltText("IMDB")).toBeInTheDocument();
@@ -29,8 +27,10 @@ describe("star-rating-layout", () => {
     expect(getByText("55%")).toBeInTheDocument();
   });
 
-  it("should toggle the ratings breakdown with mouseEnter and mouseLeave when mobile", async () => {
-    const { getByTestId } = render(<StarRatingLayout ratings={test.ratings} />);
+  it("should toggle the ratings breakdown with mouseEnter and mouseLeave when mobile", async ({
+    ratings,
+  }) => {
+    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
 
     const starRatingLayout = getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
@@ -61,8 +61,10 @@ describe("star-rating-layout", () => {
     );
   });
 
-  it("should toggle the ratings breakdown with click when mobile", async () => {
-    const { getByTestId } = render(<StarRatingLayout ratings={test.ratings} />);
+  it("should toggle the ratings breakdown with click when mobile", async ({
+    ratings,
+  }) => {
+    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
 
     const starRatingLayout = getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
@@ -93,11 +95,13 @@ describe("star-rating-layout", () => {
     );
   });
 
-  it("should toggle the ratings breakdown with mouseEnter and mouseLeave when above mobile", async () => {
+  it("should toggle the ratings breakdown with mouseEnter and mouseLeave when above mobile", async ({
+    ratings,
+  }) => {
     // Mock a 660 pixel width
     window.matchMedia = createMatchMedia(660);
 
-    const { getByTestId } = render(<StarRatingLayout ratings={test.ratings} />);
+    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
 
     const starRatingLayout = getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
@@ -128,11 +132,13 @@ describe("star-rating-layout", () => {
     );
   });
 
-  it("should toggle the ratings breakdown with click when above mobile", async () => {
+  it("should toggle the ratings breakdown with click when above mobile", async ({
+    ratings,
+  }) => {
     // Mock a 660 pixel width
     window.matchMedia = createMatchMedia(660);
 
-    const { getByTestId } = render(<StarRatingLayout ratings={test.ratings} />);
+    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
 
     const starRatingLayout = getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;

--- a/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { createMatchMedia } from "../../../../../../utils/create-match-media";
 import { StarRatingLayout } from "./star-rating-layout";
 
@@ -15,24 +15,22 @@ describe("star-rating-layout", () => {
   it("should render the five-star rating and ratings breakdown", ({
     ratings,
   }) => {
-    const { getAllByAltText, getByAltText, getByText } = render(
-      <StarRatingLayout ratings={ratings} />
-    );
-    expect(getAllByAltText(/star-/)).toHaveLength(5);
-    expect(getByAltText("IMDB")).toBeInTheDocument();
-    expect(getByText("67%")).toBeInTheDocument();
-    expect(getByAltText("ROTTEN_TOMATOES")).toBeInTheDocument();
-    expect(getByText("68%")).toBeInTheDocument();
-    expect(getByAltText("METACRITIC")).toBeInTheDocument();
-    expect(getByText("55%")).toBeInTheDocument();
+    render(<StarRatingLayout ratings={ratings} />);
+    expect(screen.getAllByAltText(/star-/)).toHaveLength(5);
+    expect(screen.getByAltText("IMDB")).toBeInTheDocument();
+    expect(screen.getByText("67%")).toBeInTheDocument();
+    expect(screen.getByAltText("ROTTEN_TOMATOES")).toBeInTheDocument();
+    expect(screen.getByText("68%")).toBeInTheDocument();
+    expect(screen.getByAltText("METACRITIC")).toBeInTheDocument();
+    expect(screen.getByText("55%")).toBeInTheDocument();
   });
 
   it("should toggle the ratings breakdown with mouseEnter and mouseLeave when mobile", async ({
     ratings,
   }) => {
-    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
+    render(<StarRatingLayout ratings={ratings} />);
 
-    const starRatingLayout = getByTestId("starRatingLayout");
+    const starRatingLayout = screen.getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
 
     expect(ratingsBreakdown).not.toHaveStyle({
@@ -64,9 +62,9 @@ describe("star-rating-layout", () => {
   it("should toggle the ratings breakdown with click when mobile", async ({
     ratings,
   }) => {
-    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
+    render(<StarRatingLayout ratings={ratings} />);
 
-    const starRatingLayout = getByTestId("starRatingLayout");
+    const starRatingLayout = screen.getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
 
     expect(ratingsBreakdown).not.toHaveStyle({
@@ -101,9 +99,9 @@ describe("star-rating-layout", () => {
     // Mock a 660 pixel width
     window.matchMedia = createMatchMedia(660);
 
-    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
+    render(<StarRatingLayout ratings={ratings} />);
 
-    const starRatingLayout = getByTestId("starRatingLayout");
+    const starRatingLayout = screen.getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
 
     expect(ratingsBreakdown).toHaveStyle({
@@ -138,9 +136,9 @@ describe("star-rating-layout", () => {
     // Mock a 660 pixel width
     window.matchMedia = createMatchMedia(660);
 
-    const { getByTestId } = render(<StarRatingLayout ratings={ratings} />);
+    render(<StarRatingLayout ratings={ratings} />);
 
-    const starRatingLayout = getByTestId("starRatingLayout");
+    const starRatingLayout = screen.getByTestId("starRatingLayout");
     const ratingsBreakdown = starRatingLayout.lastChild;
 
     expect(ratingsBreakdown).toHaveStyle({

--- a/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Trailer from "./trailer";
 import { vi } from "vitest";
 
@@ -15,10 +15,11 @@ describe("trailer", () => {
   it("should call onComplete when clicking on the trailer component and overlay mode is enabled", async ({
     trailerId,
     onComplete,
+    user,
   }) => {
     render(<Trailer overlay trailerId={trailerId} onComplete={onComplete} />);
 
-    fireEvent.click(screen.getByLabelText("Trailer"));
+    await user.click(screen.getByLabelText("Trailer"));
     expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Trailer from "./trailer";
 import { vi } from "vitest";
 
@@ -16,11 +16,9 @@ describe("trailer", () => {
     trailerId,
     onComplete,
   }) => {
-    const { getByLabelText } = render(
-      <Trailer overlay trailerId={trailerId} onComplete={onComplete} />
-    );
+    render(<Trailer overlay trailerId={trailerId} onComplete={onComplete} />);
 
-    fireEvent.click(getByLabelText("Trailer"));
+    fireEvent.click(screen.getByLabelText("Trailer"));
     expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.jsx
@@ -7,25 +7,20 @@ vi.mock("react-youtube", () => ({
 }));
 
 describe("trailer", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      trailerId: "test123",
-      onComplete: vi.fn(),
-    };
+  beforeEach((context) => {
+    context.trailerId = "test123";
+    context.onComplete = vi.fn();
   });
 
-  it("should call onComplete when clicking on the trailer component and overlay mode is enabled", async () => {
+  it("should call onComplete when clicking on the trailer component and overlay mode is enabled", async ({
+    trailerId,
+    onComplete,
+  }) => {
     const { getByLabelText } = render(
-      <Trailer
-        overlay
-        trailerId={test.trailerId}
-        onComplete={test.onComplete}
-      />
+      <Trailer overlay trailerId={trailerId} onComplete={onComplete} />
     );
 
     fireEvent.click(getByLabelText("Trailer"));
-    expect(test.onComplete).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/full-detail/full-detail.skeleton.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.skeleton.jsx
@@ -23,6 +23,7 @@ export const FullDetailSkeleton = ({ showCloseButton, small, onClose }) => (
 
     <BackdropWrapper>
       <Skeleton
+        data-testid="skeleton"
         variant="rectangular"
         width="100%"
         height="100%"
@@ -33,6 +34,7 @@ export const FullDetailSkeleton = ({ showCloseButton, small, onClose }) => (
     <MovieInfo>
       <Poster>
         <Skeleton
+          data-testid="skeleton"
           variant="rectangular"
           width={(small ? 300 : 400) * 0.64}
           height={small ? 300 : 400}
@@ -41,24 +43,78 @@ export const FullDetailSkeleton = ({ showCloseButton, small, onClose }) => (
       </Poster>
 
       <MovieTitle>
-        <Skeleton variant="text" width={300} height={60} animation="wave" />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width={300}
+          height={60}
+          animation="wave"
+        />
       </MovieTitle>
 
       <MovieData>
-        <Skeleton variant="text" width={50} height={40} animation="wave" />
-        <Skeleton variant="text" width={50} height={40} animation="wave" />
-        <Skeleton variant="text" width={50} height={40} animation="wave" />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width={50}
+          height={40}
+          animation="wave"
+        />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width={50}
+          height={40}
+          animation="wave"
+        />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width={50}
+          height={40}
+          animation="wave"
+        />
       </MovieData>
 
       <PlotLayout>
-        <Skeleton variant="text" width="100%" height={30} animation="wave" />
-        <Skeleton variant="text" width="100%" height={30} animation="wave" />
-        <Skeleton variant="text" width="100%" height={30} animation="wave" />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width="100%"
+          height={30}
+          animation="wave"
+        />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width="100%"
+          height={30}
+          animation="wave"
+        />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width="100%"
+          height={30}
+          animation="wave"
+        />
       </PlotLayout>
 
       <Actions>
-        <Skeleton variant="text" width={100} height={40} animation="wave" />
-        <Skeleton variant="text" width={100} height={40} animation="wave" />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width={100}
+          height={40}
+          animation="wave"
+        />
+        <Skeleton
+          data-testid="skeleton"
+          variant="text"
+          width={100}
+          height={40}
+          animation="wave"
+        />
       </Actions>
     </MovieInfo>
   </FullDetailLayout>

--- a/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import { GET_THIRD_PARTY_MOVIE_FULL_DETAILS } from "../../../../graphql/queries";
 import { buildThirdPartyMovieMock } from "../../../../utils/build-third-party-movie-mock";
+import { screen } from "@testing-library/dom";
 
 vi.mock("uuid", () => ({
   v4: () => "111-222-333",
@@ -28,13 +29,15 @@ const GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK = {
 
 describe("full-detail skeletons", () => {
   it("should render the skeletons when loading", async () => {
-    const { findAllByTestId } = renderWithProviders(
+    renderWithProviders(
       <FullDetail movie={{ title: "test", imdbID: "tt0258463" }} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
     );
 
-    expect((await findAllByTestId("skeleton")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByTestId("skeleton")).length).toBeGreaterThan(
+      0
+    );
   });
 });

--- a/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
@@ -1,7 +1,7 @@
 import FullDetail from "./full-detail";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
-import { screen, waitFor } from "@testing-library/dom";
+import { waitFor } from "@testing-library/dom";
 import { GET_THIRD_PARTY_MOVIE_FULL_DETAILS } from "../../../../graphql/queries";
 import { buildThirdPartyMovieMock } from "../../../../utils/build-third-party-movie-mock";
 
@@ -27,26 +27,15 @@ const GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK = {
   },
 };
 
-// This test always fails because renderWithProviders has a small sleep
-// that waits for the loading state of the mocks to move past "loading: true".
-// Mocking loading: true doesn't work.
-// https://www.apollographql.com/docs/react/development-testing/testing/#testing-the-loading-and-success-states
-// I need to remove that and then update all the tests to use findBy to wait for the post-loading (data) state to appear.
-describe.skip("full-detail skeletons", () => {
+describe("full-detail skeletons", () => {
   it("should render the skeletons when loading", async () => {
-    renderWithProviders(
+    const { findAllByTestId } = renderWithProviders(
       <FullDetail movie={{ title: "test", imdbID: "tt0258463" }} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
     );
 
-    screen.debug();
-
-    await waitFor(() =>
-      expect(
-        document.getElementsByClassName("MuiSkeleton-root").length
-      ).toBeGreaterThan(0)
-    );
+    expect((await findAllByTestId("skeleton")).length).toBeGreaterThan(0);
   });
 });

--- a/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
@@ -1,7 +1,6 @@
 import FullDetail from "./full-detail";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
-import { waitFor } from "@testing-library/dom";
 import { GET_THIRD_PARTY_MOVIE_FULL_DETAILS } from "../../../../graphql/queries";
 import { buildThirdPartyMovieMock } from "../../../../utils/build-third-party-movie-mock";
 

--- a/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.skeleton.test.jsx
@@ -27,7 +27,7 @@ const GET_THIRD_PARTY_MOVIE_FULL_DETAILS_LOADING_MOCK = {
 
 describe("full-detail skeletons", () => {
   it("should render the skeletons when loading", async () => {
-    await renderWithProviders(
+    renderWithProviders(
       <FullDetail movie={{ title: "test", imdbID: "tt0258463" }} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_LOADING_MOCK],

--- a/packages/web/src/components/app/components/full-detail/full-detail.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.test.jsx
@@ -179,17 +179,14 @@ describe("full-detail", () => {
   });
 
   it("should render the movie details", async ({ props }) => {
-    const { getByText, getByLabelText } = renderWithProviders(
+    const { getByText, findByLabelText } = renderWithProviders(
       <FullDetail {...props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
     );
 
-    await waitFor(() =>
-      expect(getByLabelText(/Bourne.*Poster/)).toBeInTheDocument()
-    );
-
+    expect(await findByLabelText(/Bourne.*Poster/)).toBeInTheDocument();
     expect(getByText("1h 59m")).toBeInTheDocument();
     expect(getByText("2002")).toBeInTheDocument();
     expect(getByText("Action")).toBeInTheDocument();
@@ -200,13 +197,14 @@ describe("full-detail", () => {
   it("should search when the movie poster is clicked", async ({ props }) => {
     window.open = vi.fn();
 
-    const { getByLabelText } = renderWithProviders(<FullDetail {...props} />, {
-      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-    });
-
-    await waitFor(() =>
-      expect(getByLabelText(/Bourne.*Poster/)).toBeInTheDocument()
+    const { getByLabelText, findByLabelText } = renderWithProviders(
+      <FullDetail {...props} />,
+      {
+        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+      }
     );
+
+    expect(await findByLabelText(/Bourne.*Poster/)).toBeInTheDocument();
     fireEvent.click(getByLabelText(/Bourne.*Poster/));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/themoviedb.*Bourne/),
@@ -227,19 +225,19 @@ describe("full-detail", () => {
   it("should show the background saved to the DB if present", async ({
     props,
   }) => {
-    const { getByTestId } = renderWithProviders(<FullDetail {...props} />, {
+    const { findByTestId } = renderWithProviders(<FullDetail {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    await waitFor(() =>
-      expect(getByTestId("http://image.tmdb.org/t/1.jpg")).toBeInTheDocument()
-    );
+    expect(
+      await findByTestId("http://image.tmdb.org/t/1.jpg")
+    ).toBeInTheDocument();
   });
 
   it("should show the first backdrop in the list if no background is in the DB", async ({
     props,
   }) => {
-    const { getByTestId } = renderWithProviders(
+    const { findByTestId } = renderWithProviders(
       <FullDetail
         {...props}
         movie={{ ...props.movie, background: undefined }}
@@ -247,25 +245,26 @@ describe("full-detail", () => {
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
-    await waitFor(() =>
-      expect(getByTestId("http://image.tmdb.org/t/1.jpg")).toBeInTheDocument()
-    );
+    expect(
+      await findByTestId("http://image.tmdb.org/t/1.jpg")
+    ).toBeInTheDocument();
   });
 
   it("should change to the previous background when the left button is pressed", async ({
     props,
     user,
   }) => {
-    const { getByTestId } = renderWithProviders(<FullDetail {...props} />, {
-      mocks: [
-        GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
-        EDIT_MOVIE_MUTATION_PREV_BG,
-      ],
-    });
-
-    await waitFor(() =>
-      expect(getByTestId("ChevronLeftIcon")).toBeInTheDocument()
+    const { getByTestId, findByTestId } = renderWithProviders(
+      <FullDetail {...props} />,
+      {
+        mocks: [
+          GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
+          EDIT_MOVIE_MUTATION_PREV_BG,
+        ],
+      }
     );
+
+    expect(await findByTestId("ChevronLeftIcon")).toBeInTheDocument();
     await user.click(getByTestId("ChevronLeftIcon"));
     await waitFor(() =>
       expect(EDIT_MOVIE_MUTATION_PREV_BG.newData).toHaveBeenCalled()
@@ -294,16 +293,14 @@ describe("full-detail", () => {
   });
 
   it("should launch the trailer", async ({ props }) => {
-    const { getByRole, getByLabelText, queryByLabelText } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
+    const { findByRole, getByRole, getByLabelText, queryByLabelText } =
+      renderWithProviders(<FullDetail {...props} />, {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+      });
 
-    await waitFor(() =>
-      expect(getByRole("button", { name: "Watch Trailer" })).toBeInTheDocument()
-    );
+    expect(
+      await findByRole("button", { name: "Watch Trailer" })
+    ).toBeInTheDocument();
     expect(queryByLabelText("Trailer")).not.toBeInTheDocument();
     fireEvent.click(getByRole("button", { name: "Watch Trailer" }));
     expect(getByLabelText("Trailer")).toBeInTheDocument();
@@ -313,16 +310,14 @@ describe("full-detail", () => {
     // Mock a 500 pixel width
     window.matchMedia = createMatchMedia(500);
 
-    const { getByRole, getByLabelText, queryByLabelText } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
+    const { findByRole, getByRole, getByLabelText, queryByLabelText } =
+      renderWithProviders(<FullDetail {...props} />, {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+      });
 
-    await waitFor(() =>
-      expect(getByRole("button", { name: "Watch Trailer" })).toBeInTheDocument()
-    );
+    expect(
+      await findByRole("button", { name: "Watch Trailer" })
+    ).toBeInTheDocument();
     expect(queryByLabelText("Trailer")).not.toBeInTheDocument();
     fireEvent.click(getByRole("button", { name: "Watch Trailer" }));
     const trailerElement = getByLabelText("Trailer");
@@ -332,14 +327,14 @@ describe("full-detail", () => {
   it("should show a logo for the source and stream the movie when clicked", async ({
     props,
   }) => {
-    const { getByAltText } = renderWithProviders(<FullDetail {...props} />, {
-      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-    });
-
-    await waitFor(() =>
-      expect(getByAltText(sourceLabels[1])).toBeInTheDocument()
+    const { findByAltText, getByAltText } = renderWithProviders(
+      <FullDetail {...props} />,
+      {
+        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+      }
     );
 
+    expect(await findByAltText(sourceLabels[1])).toBeInTheDocument();
     fireEvent.click(getByAltText(sourceLabels[1]));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/netflix.*Bourne/),
@@ -348,21 +343,18 @@ describe("full-detail", () => {
   });
 
   it("should not stream when the source logo is DVD", async ({ props }) => {
-    const { getByAltText } = renderWithProviders(
+    const { findByAltText, getByAltText } = renderWithProviders(
       <FullDetail {...props} movie={{ ...props.movie, source: sources.DVD }} />,
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
-    await waitFor(() =>
-      expect(getByAltText(sourceLabels[sources.DVD])).toBeInTheDocument()
-    );
-
+    expect(await findByAltText(sourceLabels[sources.DVD])).toBeInTheDocument();
     fireEvent.click(getByAltText(sourceLabels[sources.DVD]));
     expect(window.open).not.toHaveBeenCalled();
   });
 
   it("should not stream when the source logo is None", async ({ props }) => {
-    const { getByAltText } = renderWithProviders(
+    const { findByAltText, getByAltText } = renderWithProviders(
       <FullDetail
         {...props}
         movie={{ ...props.movie, source: sources.NONE }}
@@ -370,10 +362,7 @@ describe("full-detail", () => {
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
-    await waitFor(() =>
-      expect(getByAltText(sourceLabels[sources.NONE])).toBeInTheDocument()
-    );
-
+    expect(await findByAltText(sourceLabels[sources.NONE])).toBeInTheDocument();
     fireEvent.click(getByAltText(sourceLabels[sources.NONE]));
     expect(window.open).not.toHaveBeenCalled();
   });
@@ -383,13 +372,16 @@ describe("full-detail", () => {
   }) => {
     window.open = vi.fn();
 
-    const { getByRole } = renderWithProviders(<FullDetail {...props} />, {
-      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-    });
-
-    await waitFor(() =>
-      expect(getByRole("button", { name: "Stream Movie" })).toBeInTheDocument()
+    const { findByRole, getByRole } = renderWithProviders(
+      <FullDetail {...props} />,
+      {
+        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+      }
     );
+
+    expect(
+      await findByRole("button", { name: "Stream Movie" })
+    ).toBeInTheDocument();
     fireEvent.click(getByRole("button", { name: "Stream Movie" }));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/netflix.*Bourne/),
@@ -417,7 +409,7 @@ describe("full-detail", () => {
   }) => {
     window.open = vi.fn();
 
-    const { getByRole } = renderWithProviders(
+    const { findByRole, getByRole } = renderWithProviders(
       <FullDetail
         {...props}
         movie={{ ...props.movie, source: sources.NONE }}
@@ -425,11 +417,9 @@ describe("full-detail", () => {
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
-    await waitFor(() =>
-      expect(
-        getByRole("button", { name: "Torrent Search" })
-      ).toBeInTheDocument()
-    );
+    expect(
+      await findByRole("button", { name: "Torrent Search" })
+    ).toBeInTheDocument();
     fireEvent.click(getByRole("button", { name: "Torrent Search" }));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/1337x.to.*Bourne/),
@@ -438,18 +428,14 @@ describe("full-detail", () => {
   });
 
   it("should render the footer buttons", async ({ props }) => {
-    const { getByAltText } = renderWithProviders(<FullDetail {...props} />, {
+    const { findByAltText } = renderWithProviders(<FullDetail {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    await waitFor(() =>
-      expect(getByAltText("Search TMDB")).toBeInTheDocument()
-    );
-    await waitFor(() =>
-      expect(getByAltText("Search IMDB")).toBeInTheDocument()
-    );
-    await waitFor(() =>
-      expect(getByAltText("Search Common Sense Media")).toBeInTheDocument()
-    );
+    expect(await findByAltText("Search TMDB")).toBeInTheDocument();
+    expect(await findByAltText("Search IMDB")).toBeInTheDocument();
+    expect(
+      await findByAltText("Search Common Sense Media")
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/full-detail/full-detail.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.test.jsx
@@ -1,5 +1,5 @@
 import FullDetail from "./full-detail";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, waitFor, screen } from "@testing-library/react";
 import { EDIT_MOVIE } from "../../../../graphql/mutations";
 import { sources } from "md4k-constants";
 import { vi, beforeEach } from "vitest";
@@ -179,33 +179,29 @@ describe("full-detail", () => {
   });
 
   it("should render the movie details", async ({ props }) => {
-    const { getByText, findByLabelText } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    expect(await findByLabelText(/Bourne.*Poster/)).toBeInTheDocument();
-    expect(getByText("1h 59m")).toBeInTheDocument();
-    expect(getByText("2002")).toBeInTheDocument();
-    expect(getByText("Action")).toBeInTheDocument();
-    expect(getByText("PG-13")).toBeInTheDocument();
-    expect(getByText("Wounded to the brink of death")).toBeInTheDocument();
+    expect(await screen.findByLabelText(/Bourne.*Poster/)).toBeInTheDocument();
+    expect(screen.getByText("1h 59m")).toBeInTheDocument();
+    expect(screen.getByText("2002")).toBeInTheDocument();
+    expect(screen.getByText("Action")).toBeInTheDocument();
+    expect(screen.getByText("PG-13")).toBeInTheDocument();
+    expect(
+      screen.getByText("Wounded to the brink of death")
+    ).toBeInTheDocument();
   });
 
   it("should search when the movie poster is clicked", async ({ props }) => {
     window.open = vi.fn();
 
-    const { getByLabelText, findByLabelText } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    expect(await findByLabelText(/Bourne.*Poster/)).toBeInTheDocument();
-    fireEvent.click(getByLabelText(/Bourne.*Poster/));
+    expect(await screen.findByLabelText(/Bourne.*Poster/)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Bourne.*Poster/));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/themoviedb.*Bourne/),
       "moviedb"
@@ -213,31 +209,30 @@ describe("full-detail", () => {
   });
 
   it("should show the close button", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(
-      <FullDetail {...props} showCloseButton={true} />,
-      { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
-    );
+    renderWithProviders(<FullDetail {...props} showCloseButton={true} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByTestId("CloseThickIcon"));
+    fireEvent.click(screen.getByTestId("CloseThickIcon"));
     expect(props.onClose).toHaveBeenCalled();
   });
 
   it("should show the background saved to the DB if present", async ({
     props,
   }) => {
-    const { findByTestId } = renderWithProviders(<FullDetail {...props} />, {
+    renderWithProviders(<FullDetail {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
     expect(
-      await findByTestId("http://image.tmdb.org/t/1.jpg")
+      await screen.findByTestId("http://image.tmdb.org/t/1.jpg")
     ).toBeInTheDocument();
   });
 
   it("should show the first backdrop in the list if no background is in the DB", async ({
     props,
   }) => {
-    const { findByTestId } = renderWithProviders(
+    renderWithProviders(
       <FullDetail
         {...props}
         movie={{ ...props.movie, background: undefined }}
@@ -246,7 +241,7 @@ describe("full-detail", () => {
     );
 
     expect(
-      await findByTestId("http://image.tmdb.org/t/1.jpg")
+      await screen.findByTestId("http://image.tmdb.org/t/1.jpg")
     ).toBeInTheDocument();
   });
 
@@ -254,18 +249,15 @@ describe("full-detail", () => {
     props,
     user,
   }) => {
-    const { getByTestId, findByTestId } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
-        mocks: [
-          GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
-          EDIT_MOVIE_MUTATION_PREV_BG,
-        ],
-      }
-    );
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [
+        GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
+        EDIT_MOVIE_MUTATION_PREV_BG,
+      ],
+    });
 
-    expect(await findByTestId("ChevronLeftIcon")).toBeInTheDocument();
-    await user.click(getByTestId("ChevronLeftIcon"));
+    expect(await screen.findByTestId("ChevronLeftIcon")).toBeInTheDocument();
+    await user.click(screen.getByTestId("ChevronLeftIcon"));
     await waitFor(() =>
       expect(EDIT_MOVIE_MUTATION_PREV_BG.newData).toHaveBeenCalled()
     );
@@ -275,67 +267,59 @@ describe("full-detail", () => {
     props,
     user,
   }) => {
-    const { getByTestId, findByTestId } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
-        mocks: [
-          GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
-          EDIT_MOVIE_MUTATION_NEXT_BG,
-        ],
-      }
-    );
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [
+        GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
+        EDIT_MOVIE_MUTATION_NEXT_BG,
+      ],
+    });
 
-    expect(await findByTestId("ChevronRightIcon")).toBeInTheDocument();
-    await user.click(getByTestId("ChevronRightIcon"));
+    expect(await screen.findByTestId("ChevronRightIcon")).toBeInTheDocument();
+    await user.click(screen.getByTestId("ChevronRightIcon"));
     await waitFor(() =>
       expect(EDIT_MOVIE_MUTATION_NEXT_BG.newData).toHaveBeenCalled()
     );
   });
 
   it("should launch the trailer", async ({ props }) => {
-    const { findByRole, getByRole, getByLabelText, queryByLabelText } =
-      renderWithProviders(<FullDetail {...props} />, {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     expect(
-      await findByRole("button", { name: "Watch Trailer" })
+      await screen.findByRole("button", { name: "Watch Trailer" })
     ).toBeInTheDocument();
-    expect(queryByLabelText("Trailer")).not.toBeInTheDocument();
-    fireEvent.click(getByRole("button", { name: "Watch Trailer" }));
-    expect(getByLabelText("Trailer")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Trailer")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Watch Trailer" }));
+    expect(screen.getByLabelText("Trailer")).toBeInTheDocument();
   });
 
   it("should launch the trailer as an overlay", async ({ props }) => {
     // Mock a 500 pixel width
     window.matchMedia = createMatchMedia(500);
 
-    const { findByRole, getByRole, getByLabelText, queryByLabelText } =
-      renderWithProviders(<FullDetail {...props} />, {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     expect(
-      await findByRole("button", { name: "Watch Trailer" })
+      await screen.findByRole("button", { name: "Watch Trailer" })
     ).toBeInTheDocument();
-    expect(queryByLabelText("Trailer")).not.toBeInTheDocument();
-    fireEvent.click(getByRole("button", { name: "Watch Trailer" }));
-    const trailerElement = getByLabelText("Trailer");
+    expect(screen.queryByLabelText("Trailer")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Watch Trailer" }));
+    const trailerElement = screen.getByLabelText("Trailer");
     expect(document.body).toContainElement(trailerElement);
   });
 
   it("should show a logo for the source and stream the movie when clicked", async ({
     props,
   }) => {
-    const { findByAltText, getByAltText } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    expect(await findByAltText(sourceLabels[1])).toBeInTheDocument();
-    fireEvent.click(getByAltText(sourceLabels[1]));
+    expect(await screen.findByAltText(sourceLabels[1])).toBeInTheDocument();
+    fireEvent.click(screen.getByAltText(sourceLabels[1]));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/netflix.*Bourne/),
       "movieView"
@@ -343,18 +327,20 @@ describe("full-detail", () => {
   });
 
   it("should not stream when the source logo is DVD", async ({ props }) => {
-    const { findByAltText, getByAltText } = renderWithProviders(
+    renderWithProviders(
       <FullDetail {...props} movie={{ ...props.movie, source: sources.DVD }} />,
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
-    expect(await findByAltText(sourceLabels[sources.DVD])).toBeInTheDocument();
-    fireEvent.click(getByAltText(sourceLabels[sources.DVD]));
+    expect(
+      await screen.findByAltText(sourceLabels[sources.DVD])
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByAltText(sourceLabels[sources.DVD]));
     expect(window.open).not.toHaveBeenCalled();
   });
 
   it("should not stream when the source logo is None", async ({ props }) => {
-    const { findByAltText, getByAltText } = renderWithProviders(
+    renderWithProviders(
       <FullDetail
         {...props}
         movie={{ ...props.movie, source: sources.NONE }}
@@ -362,8 +348,10 @@ describe("full-detail", () => {
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
-    expect(await findByAltText(sourceLabels[sources.NONE])).toBeInTheDocument();
-    fireEvent.click(getByAltText(sourceLabels[sources.NONE]));
+    expect(
+      await screen.findByAltText(sourceLabels[sources.NONE])
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByAltText(sourceLabels[sources.NONE]));
     expect(window.open).not.toHaveBeenCalled();
   });
 
@@ -372,17 +360,14 @@ describe("full-detail", () => {
   }) => {
     window.open = vi.fn();
 
-    const { findByRole, getByRole } = renderWithProviders(
-      <FullDetail {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     expect(
-      await findByRole("button", { name: "Stream Movie" })
+      await screen.findByRole("button", { name: "Stream Movie" })
     ).toBeInTheDocument();
-    fireEvent.click(getByRole("button", { name: "Stream Movie" }));
+    fireEvent.click(screen.getByRole("button", { name: "Stream Movie" }));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/netflix.*Bourne/),
       "movieView"
@@ -392,14 +377,14 @@ describe("full-detail", () => {
   it("should not show a stream option when the source is not streamable", async ({
     props,
   }) => {
-    const { queryByRole } = renderWithProviders(
+    renderWithProviders(
       <FullDetail {...props} movie={{ ...props.movie, source: sources.DVD }} />,
       { mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK] }
     );
 
     await waitFor(() =>
       expect(
-        queryByRole("button", { name: "Stream Movie" })
+        screen.queryByRole("button", { name: "Stream Movie" })
       ).not.toBeInTheDocument()
     );
   });
@@ -409,7 +394,7 @@ describe("full-detail", () => {
   }) => {
     window.open = vi.fn();
 
-    const { findByRole, getByRole } = renderWithProviders(
+    renderWithProviders(
       <FullDetail
         {...props}
         movie={{ ...props.movie, source: sources.NONE }}
@@ -418,9 +403,9 @@ describe("full-detail", () => {
     );
 
     expect(
-      await findByRole("button", { name: "Torrent Search" })
+      await screen.findByRole("button", { name: "Torrent Search" })
     ).toBeInTheDocument();
-    fireEvent.click(getByRole("button", { name: "Torrent Search" }));
+    fireEvent.click(screen.getByRole("button", { name: "Torrent Search" }));
     expect(window.open).toHaveBeenCalledWith(
       expect.stringMatching(/1337x.to.*Bourne/),
       "movieView"
@@ -428,14 +413,14 @@ describe("full-detail", () => {
   });
 
   it("should render the footer buttons", async ({ props }) => {
-    const { findByAltText } = renderWithProviders(<FullDetail {...props} />, {
+    renderWithProviders(<FullDetail {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    expect(await findByAltText("Search TMDB")).toBeInTheDocument();
-    expect(await findByAltText("Search IMDB")).toBeInTheDocument();
+    expect(await screen.findByAltText("Search TMDB")).toBeInTheDocument();
+    expect(await screen.findByAltText("Search IMDB")).toBeInTheDocument();
     expect(
-      await findByAltText("Search Common Sense Media")
+      await screen.findByAltText("Search Common Sense Media")
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
@@ -10,26 +10,22 @@ vi.mock("@mui/material", async () => {
 });
 
 describe("action-bar", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      onAdd: vi.fn(),
-      onPick: vi.fn(),
-    };
+  beforeEach((context) => {
+    context.onAdd = vi.fn();
+    context.onPick = vi.fn();
   });
 
-  it("should not render the bar when disabled", async () => {
+  it("should not render the bar when disabled", async ({ onAdd, onPick }) => {
     const { queryByText } = renderWithProviders(
-      <ActionBar disabled={true} onAdd={test.onAdd} onPick={test.onPick} />
+      <ActionBar disabled={true} onAdd={onAdd} onPick={onPick} />
     );
 
     expect(queryByText("Added")).not.toBeInTheDocument();
   });
 
-  it("should not render the bar when enabled", async () => {
+  it("should not render the bar when enabled", async ({ onAdd, onPick }) => {
     const { getByText, getByLabelText } = renderWithProviders(
-      <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
+      <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
     expect(getByText("Added")).toBeInTheDocument();
@@ -37,42 +33,54 @@ describe("action-bar", () => {
     expect(getByLabelText("Pick A Movie")).toBeInTheDocument();
   });
 
-  it("should render the Add Movie button with a label when space exists", async () => {
+  it("should render the Add Movie button with a label when space exists", async ({
+    onAdd,
+    onPick,
+  }) => {
     const { getByText, getByLabelText } = renderWithProviders(
-      <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
+      <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
     expect(getByLabelText("Add Movie")).toBeInTheDocument();
     expect(getByText("Add Movie")).toBeInTheDocument();
   });
 
-  it("should render the Add Movie button without a label when space is limited", async () => {
+  it("should render the Add Movie button without a label when space is limited", async ({
+    onAdd,
+    onPick,
+  }) => {
     // eslint-disable-next-line no-import-assign
     mui.useMediaQuery = vi.fn().mockReturnValue(false);
 
     const { queryByText, getByLabelText } = renderWithProviders(
-      <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
+      <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
     expect(getByLabelText("Add Movie")).toBeInTheDocument();
     expect(queryByText("Add Movie")).not.toBeInTheDocument();
   });
 
-  it("should call onAdd when Add Movie is pressed", async () => {
+  it("should call onAdd when Add Movie is pressed", async ({
+    onAdd,
+    onPick,
+  }) => {
     const { getByLabelText } = renderWithProviders(
-      <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
+      <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
     fireEvent.click(getByLabelText("Add Movie"));
-    expect(test.onAdd).toBeCalled();
+    expect(onAdd).toBeCalled();
   });
 
-  it("should call onPick when Pick A Movie is pressed", async () => {
+  it("should call onPick when Pick A Movie is pressed", async ({
+    onAdd,
+    onPick,
+  }) => {
     const { getByRole } = renderWithProviders(
-      <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
+      <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
     fireEvent.click(getByRole("button", { name: "Pick A Movie" }));
-    expect(test.onPick).toBeCalled();
+    expect(onPick).toBeCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
@@ -15,7 +15,7 @@ describe("action-bar", () => {
     context.onPick = vi.fn();
   });
 
-  it("should not render the bar when disabled", async ({ onAdd, onPick }) => {
+  it("should not render the bar when disabled", ({ onAdd, onPick }) => {
     renderWithProviders(
       <ActionBar disabled={true} onAdd={onAdd} onPick={onPick} />
     );
@@ -23,7 +23,7 @@ describe("action-bar", () => {
     expect(screen.queryByText("Added")).not.toBeInTheDocument();
   });
 
-  it("should not render the bar when enabled", async ({ onAdd, onPick }) => {
+  it("should not render the bar when enabled", ({ onAdd, onPick }) => {
     renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
@@ -33,7 +33,7 @@ describe("action-bar", () => {
     expect(screen.getByLabelText("Pick A Movie")).toBeInTheDocument();
   });
 
-  it("should render the Add Movie button with a label when space exists", async ({
+  it("should render the Add Movie button with a label when space exists", ({
     onAdd,
     onPick,
   }) => {
@@ -45,7 +45,7 @@ describe("action-bar", () => {
     expect(screen.getByText("Add Movie")).toBeInTheDocument();
   });
 
-  it("should render the Add Movie button without a label when space is limited", async ({
+  it("should render the Add Movie button without a label when space is limited", ({
     onAdd,
     onPick,
   }) => {

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import ActionBar from "./action-bar";
@@ -16,33 +16,33 @@ describe("action-bar", () => {
   });
 
   it("should not render the bar when disabled", async ({ onAdd, onPick }) => {
-    const { queryByText } = renderWithProviders(
+    renderWithProviders(
       <ActionBar disabled={true} onAdd={onAdd} onPick={onPick} />
     );
 
-    expect(queryByText("Added")).not.toBeInTheDocument();
+    expect(screen.queryByText("Added")).not.toBeInTheDocument();
   });
 
   it("should not render the bar when enabled", async ({ onAdd, onPick }) => {
-    const { getByText, getByLabelText } = renderWithProviders(
+    renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    expect(getByText("Added")).toBeInTheDocument();
-    expect(getByLabelText("Add Movie")).toBeInTheDocument();
-    expect(getByLabelText("Pick A Movie")).toBeInTheDocument();
+    expect(screen.getByText("Added")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add Movie")).toBeInTheDocument();
+    expect(screen.getByLabelText("Pick A Movie")).toBeInTheDocument();
   });
 
   it("should render the Add Movie button with a label when space exists", async ({
     onAdd,
     onPick,
   }) => {
-    const { getByText, getByLabelText } = renderWithProviders(
+    renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    expect(getByLabelText("Add Movie")).toBeInTheDocument();
-    expect(getByText("Add Movie")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add Movie")).toBeInTheDocument();
+    expect(screen.getByText("Add Movie")).toBeInTheDocument();
   });
 
   it("should render the Add Movie button without a label when space is limited", async ({
@@ -52,23 +52,23 @@ describe("action-bar", () => {
     // eslint-disable-next-line no-import-assign
     mui.useMediaQuery = vi.fn().mockReturnValue(false);
 
-    const { queryByText, getByLabelText } = renderWithProviders(
+    renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    expect(getByLabelText("Add Movie")).toBeInTheDocument();
-    expect(queryByText("Add Movie")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Add Movie")).toBeInTheDocument();
+    expect(screen.queryByText("Add Movie")).not.toBeInTheDocument();
   });
 
   it("should call onAdd when Add Movie is pressed", async ({
     onAdd,
     onPick,
   }) => {
-    const { getByLabelText } = renderWithProviders(
+    renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    fireEvent.click(getByLabelText("Add Movie"));
+    fireEvent.click(screen.getByLabelText("Add Movie"));
     expect(onAdd).toBeCalled();
   });
 
@@ -76,11 +76,11 @@ describe("action-bar", () => {
     onAdd,
     onPick,
   }) => {
-    const { getByRole } = renderWithProviders(
+    renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    fireEvent.click(getByRole("button", { name: "Pick A Movie" }));
+    fireEvent.click(screen.getByRole("button", { name: "Pick A Movie" }));
     expect(onPick).toBeCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import ActionBar from "./action-bar";
@@ -63,24 +63,26 @@ describe("action-bar", () => {
   it("should call onAdd when Add Movie is pressed", async ({
     onAdd,
     onPick,
+    user,
   }) => {
     renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    fireEvent.click(screen.getByLabelText("Add Movie"));
+    await user.click(screen.getByLabelText("Add Movie"));
     expect(onAdd).toBeCalled();
   });
 
   it("should call onPick when Pick A Movie is pressed", async ({
     onAdd,
     onPick,
+    user,
   }) => {
     renderWithProviders(
       <ActionBar disabled={false} onAdd={onAdd} onPick={onPick} />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Pick A Movie" }));
+    await user.click(screen.getByRole("button", { name: "Pick A Movie" }));
     expect(onPick).toBeCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.jsx
@@ -20,7 +20,7 @@ describe("action-bar", () => {
   });
 
   it("should not render the bar when disabled", async () => {
-    const { queryByText } = await renderWithProviders(
+    const { queryByText } = renderWithProviders(
       <ActionBar disabled={true} onAdd={test.onAdd} onPick={test.onPick} />
     );
 
@@ -28,7 +28,7 @@ describe("action-bar", () => {
   });
 
   it("should not render the bar when enabled", async () => {
-    const { getByText, getByLabelText } = await renderWithProviders(
+    const { getByText, getByLabelText } = renderWithProviders(
       <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
     );
 
@@ -38,7 +38,7 @@ describe("action-bar", () => {
   });
 
   it("should render the Add Movie button with a label when space exists", async () => {
-    const { getByText, getByLabelText } = await renderWithProviders(
+    const { getByText, getByLabelText } = renderWithProviders(
       <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
     );
 
@@ -50,7 +50,7 @@ describe("action-bar", () => {
     // eslint-disable-next-line no-import-assign
     mui.useMediaQuery = vi.fn().mockReturnValue(false);
 
-    const { queryByText, getByLabelText } = await renderWithProviders(
+    const { queryByText, getByLabelText } = renderWithProviders(
       <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
     );
 
@@ -59,7 +59,7 @@ describe("action-bar", () => {
   });
 
   it("should call onAdd when Add Movie is pressed", async () => {
-    const { getByLabelText } = await renderWithProviders(
+    const { getByLabelText } = renderWithProviders(
       <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
     );
 
@@ -68,7 +68,7 @@ describe("action-bar", () => {
   });
 
   it("should call onPick when Pick A Movie is pressed", async () => {
-    const { getByRole } = await renderWithProviders(
+    const { getByRole } = renderWithProviders(
       <ActionBar disabled={false} onAdd={test.onAdd} onPick={test.onPick} />
     );
 

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
@@ -7,7 +7,7 @@ import {
 import SortNav from "./sort-nav";
 
 describe("sort-nav", () => {
-  it("should render all sort options", async () => {
+  it("should render all sort options", () => {
     renderWithProviders(<SortNav />);
 
     expect(screen.getByText("Added")).toBeInTheDocument();
@@ -15,7 +15,7 @@ describe("sort-nav", () => {
     expect(screen.getByText("Title")).toBeInTheDocument();
   });
 
-  it("should select added desc by default", async () => {
+  it("should select added desc by default", () => {
     renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
     expect(screen.getByText("Added")).toHaveAttribute("data-active", "true");

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
@@ -8,7 +8,7 @@ import SortNav from "./sort-nav";
 
 describe("sort-nav", () => {
   it("should render all sort options", async () => {
-    const { getByText } = await renderWithProviders(<SortNav />);
+    const { getByText } = renderWithProviders(<SortNav />);
 
     expect(getByText("Added")).toBeInTheDocument();
     expect(getByText("Runtime")).toBeInTheDocument();
@@ -16,7 +16,7 @@ describe("sort-nav", () => {
   });
 
   it("should select added desc by default", async () => {
-    const { getByText } = await renderWithProvidersAsRoute(
+    const { getByText } = renderWithProvidersAsRoute(
       <SortNav />,
       "/list/*",
       "/list/addedOn/desc"
@@ -29,7 +29,7 @@ describe("sort-nav", () => {
   });
 
   it("should toggle runtime", async () => {
-    const { getByText } = await renderWithProvidersAsRoute(
+    const { getByText } = renderWithProvidersAsRoute(
       <SortNav />,
       "/list/*",
       "/list/addedOn/desc"
@@ -55,7 +55,7 @@ describe("sort-nav", () => {
   });
 
   it("should toggle title", async () => {
-    const { getByText } = await renderWithProvidersAsRoute(
+    const { getByText } = renderWithProvidersAsRoute(
       <SortNav />,
       "/list/*",
       "/list/addedOn/desc"
@@ -75,7 +75,7 @@ describe("sort-nav", () => {
   });
 
   it("should toggle added", async () => {
-    const { getByText } = await renderWithProvidersAsRoute(
+    const { getByText } = renderWithProvidersAsRoute(
       <SortNav />,
       "/list/*",
       "/list/addedOn/desc"
@@ -95,7 +95,7 @@ describe("sort-nav", () => {
   });
 
   it("should show the correct icon for the sort direction and option", async () => {
-    const { getByText, getByTestId } = await renderWithProvidersAsRoute(
+    const { getByText, getByTestId } = renderWithProvidersAsRoute(
       <SortNav />,
       "/list/*",
       "/list/addedOn/desc"

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { sortDirection } from "../../../../../../../../constants/sorts";
 import {
   renderWithProviders,
@@ -8,129 +8,136 @@ import SortNav from "./sort-nav";
 
 describe("sort-nav", () => {
   it("should render all sort options", async () => {
-    const { getByText } = renderWithProviders(<SortNav />);
+    renderWithProviders(<SortNav />);
 
-    expect(getByText("Added")).toBeInTheDocument();
-    expect(getByText("Runtime")).toBeInTheDocument();
-    expect(getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Added")).toBeInTheDocument();
+    expect(screen.getByText("Runtime")).toBeInTheDocument();
+    expect(screen.getByText("Title")).toBeInTheDocument();
   });
 
   it("should select added desc by default", async () => {
-    const { getByText } = renderWithProvidersAsRoute(
-      <SortNav />,
-      "/list/*",
-      "/list/addedOn/desc"
-    );
+    renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    expect(getByText("Added")).toHaveAttribute("data-active", "true");
-    expect(getByText("Added")).toHaveAttribute("data-sort", sortDirection.DESC);
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "false");
-    expect(getByText("Title")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Added")).toHaveAttribute(
+      "data-sort",
+      sortDirection.DESC
+    );
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
   });
 
   it("should toggle runtime", async () => {
-    const { getByText } = renderWithProvidersAsRoute(
-      <SortNav />,
-      "/list/*",
-      "/list/addedOn/desc"
-    );
+    renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    fireEvent.click(getByText("Runtime"));
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "true");
-    expect(getByText("Runtime")).toHaveAttribute(
+    fireEvent.click(screen.getByText("Runtime"));
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Runtime")).toHaveAttribute(
       "data-sort",
       sortDirection.ASC
     );
-    expect(getByText("Added")).toHaveAttribute("data-active", "false");
-    expect(getByText("Title")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
 
-    fireEvent.click(getByText("Runtime"));
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "true");
-    expect(getByText("Runtime")).toHaveAttribute(
+    fireEvent.click(screen.getByText("Runtime"));
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Runtime")).toHaveAttribute(
       "data-sort",
       sortDirection.DESC
     );
-    expect(getByText("Added")).toHaveAttribute("data-active", "false");
-    expect(getByText("Title")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
   });
 
   it("should toggle title", async () => {
-    const { getByText } = renderWithProvidersAsRoute(
-      <SortNav />,
-      "/list/*",
-      "/list/addedOn/desc"
-    );
+    renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    fireEvent.click(getByText("Title"));
-    expect(getByText("Title")).toHaveAttribute("data-active", "true");
-    expect(getByText("Title")).toHaveAttribute("data-sort", sortDirection.ASC);
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "false");
-    expect(getByText("Added")).toHaveAttribute("data-active", "false");
-
-    fireEvent.click(getByText("Title"));
-    expect(getByText("Title")).toHaveAttribute("data-active", "true");
-    expect(getByText("Title")).toHaveAttribute("data-sort", sortDirection.DESC);
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "false");
-    expect(getByText("Added")).toHaveAttribute("data-active", "false");
-  });
-
-  it("should toggle added", async () => {
-    const { getByText } = renderWithProvidersAsRoute(
-      <SortNav />,
-      "/list/*",
-      "/list/addedOn/desc"
-    );
-
-    fireEvent.click(getByText("Added"));
-    expect(getByText("Added")).toHaveAttribute("data-active", "true");
-    expect(getByText("Added")).toHaveAttribute("data-sort", sortDirection.ASC);
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "false");
-    expect(getByText("Title")).toHaveAttribute("data-active", "false");
-
-    fireEvent.click(getByText("Added"));
-    expect(getByText("Added")).toHaveAttribute("data-active", "true");
-    expect(getByText("Added")).toHaveAttribute("data-sort", sortDirection.DESC);
-    expect(getByText("Runtime")).toHaveAttribute("data-active", "false");
-    expect(getByText("Title")).toHaveAttribute("data-active", "false");
-  });
-
-  it("should show the correct icon for the sort direction and option", async () => {
-    const { getByText, getByTestId } = renderWithProvidersAsRoute(
-      <SortNav />,
-      "/list/*",
-      "/list/addedOn/desc"
-    );
-
-    fireEvent.click(getByText("Title"));
-    expect(getByText("Title")).toHaveAttribute("data-sort", sortDirection.ASC);
-    expect(getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
-
-    fireEvent.click(getByText("Title"));
-    expect(getByText("Title")).toHaveAttribute("data-sort", sortDirection.DESC);
-    expect(getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
-
-    fireEvent.click(getByText("Runtime"));
-    expect(getByText("Runtime")).toHaveAttribute(
+    fireEvent.click(screen.getByText("Title"));
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Title")).toHaveAttribute(
       "data-sort",
       sortDirection.ASC
     );
-    expect(getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
 
-    fireEvent.click(getByText("Runtime"));
-    expect(getByText("Runtime")).toHaveAttribute(
+    fireEvent.click(screen.getByText("Title"));
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Title")).toHaveAttribute(
       "data-sort",
       sortDirection.DESC
     );
-    expect(getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
+  });
+
+  it("should toggle added", async () => {
+    renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
+
+    fireEvent.click(screen.getByText("Added"));
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Added")).toHaveAttribute(
+      "data-sort",
+      sortDirection.ASC
+    );
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
+
+    fireEvent.click(screen.getByText("Added"));
+    expect(screen.getByText("Added")).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Added")).toHaveAttribute(
+      "data-sort",
+      sortDirection.DESC
+    );
+    expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
+    expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
+  });
+
+  it("should show the correct icon for the sort direction and option", async () => {
+    renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
+
+    fireEvent.click(screen.getByText("Title"));
+    expect(screen.getByText("Title")).toHaveAttribute(
+      "data-sort",
+      sortDirection.ASC
+    );
+    expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Title"));
+    expect(screen.getByText("Title")).toHaveAttribute(
+      "data-sort",
+      sortDirection.DESC
+    );
+    expect(screen.getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Runtime"));
+    expect(screen.getByText("Runtime")).toHaveAttribute(
+      "data-sort",
+      sortDirection.ASC
+    );
+    expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Runtime"));
+    expect(screen.getByText("Runtime")).toHaveAttribute(
+      "data-sort",
+      sortDirection.DESC
+    );
+    expect(screen.getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
 
     // Added uses the opposite icon for desc (Down) and defaults to "desc" first
-    fireEvent.click(getByText("Added"));
-    expect(getByText("Added")).toHaveAttribute("data-sort", sortDirection.DESC);
-    expect(getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Added"));
+    expect(screen.getByText("Added")).toHaveAttribute(
+      "data-sort",
+      sortDirection.DESC
+    );
+    expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
 
     // Added uses the opposite icon for asc (Up)
-    fireEvent.click(getByText("Added"));
-    expect(getByText("Added")).toHaveAttribute("data-sort", sortDirection.ASC);
-    expect(getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Added"));
+    expect(screen.getByText("Added")).toHaveAttribute(
+      "data-sort",
+      sortDirection.ASC
+    );
+    expect(screen.getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { sortDirection } from "../../../../../../../../constants/sorts";
 import {
   renderWithProviders,
@@ -27,10 +27,10 @@ describe("sort-nav", () => {
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
   });
 
-  it("should toggle runtime", async () => {
+  it("should toggle runtime", async ({ user }) => {
     renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    fireEvent.click(screen.getByText("Runtime"));
+    await user.click(screen.getByText("Runtime"));
     expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "true");
     expect(screen.getByText("Runtime")).toHaveAttribute(
       "data-sort",
@@ -39,7 +39,7 @@ describe("sort-nav", () => {
     expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
 
-    fireEvent.click(screen.getByText("Runtime"));
+    await user.click(screen.getByText("Runtime"));
     expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "true");
     expect(screen.getByText("Runtime")).toHaveAttribute(
       "data-sort",
@@ -49,10 +49,10 @@ describe("sort-nav", () => {
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
   });
 
-  it("should toggle title", async () => {
+  it("should toggle title", async ({ user }) => {
     renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    fireEvent.click(screen.getByText("Title"));
+    await user.click(screen.getByText("Title"));
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "true");
     expect(screen.getByText("Title")).toHaveAttribute(
       "data-sort",
@@ -61,7 +61,7 @@ describe("sort-nav", () => {
     expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
     expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
 
-    fireEvent.click(screen.getByText("Title"));
+    await user.click(screen.getByText("Title"));
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "true");
     expect(screen.getByText("Title")).toHaveAttribute(
       "data-sort",
@@ -71,10 +71,10 @@ describe("sort-nav", () => {
     expect(screen.getByText("Added")).toHaveAttribute("data-active", "false");
   });
 
-  it("should toggle added", async () => {
+  it("should toggle added", async ({ user }) => {
     renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    fireEvent.click(screen.getByText("Added"));
+    await user.click(screen.getByText("Added"));
     expect(screen.getByText("Added")).toHaveAttribute("data-active", "true");
     expect(screen.getByText("Added")).toHaveAttribute(
       "data-sort",
@@ -83,7 +83,7 @@ describe("sort-nav", () => {
     expect(screen.getByText("Runtime")).toHaveAttribute("data-active", "false");
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
 
-    fireEvent.click(screen.getByText("Added"));
+    await user.click(screen.getByText("Added"));
     expect(screen.getByText("Added")).toHaveAttribute("data-active", "true");
     expect(screen.getByText("Added")).toHaveAttribute(
       "data-sort",
@@ -93,31 +93,33 @@ describe("sort-nav", () => {
     expect(screen.getByText("Title")).toHaveAttribute("data-active", "false");
   });
 
-  it("should show the correct icon for the sort direction and option", async () => {
+  it("should show the correct icon for the sort direction and option", async ({
+    user,
+  }) => {
     renderWithProvidersAsRoute(<SortNav />, "/list/*", "/list/addedOn/desc");
 
-    fireEvent.click(screen.getByText("Title"));
+    await user.click(screen.getByText("Title"));
     expect(screen.getByText("Title")).toHaveAttribute(
       "data-sort",
       sortDirection.ASC
     );
     expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Title"));
+    await user.click(screen.getByText("Title"));
     expect(screen.getByText("Title")).toHaveAttribute(
       "data-sort",
       sortDirection.DESC
     );
     expect(screen.getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Runtime"));
+    await user.click(screen.getByText("Runtime"));
     expect(screen.getByText("Runtime")).toHaveAttribute(
       "data-sort",
       sortDirection.ASC
     );
     expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Runtime"));
+    await user.click(screen.getByText("Runtime"));
     expect(screen.getByText("Runtime")).toHaveAttribute(
       "data-sort",
       sortDirection.DESC
@@ -125,7 +127,7 @@ describe("sort-nav", () => {
     expect(screen.getByTestId("KeyboardArrowUpIcon")).toBeInTheDocument();
 
     // Added uses the opposite icon for desc (Down) and defaults to "desc" first
-    fireEvent.click(screen.getByText("Added"));
+    await user.click(screen.getByText("Added"));
     expect(screen.getByText("Added")).toHaveAttribute(
       "data-sort",
       sortDirection.DESC
@@ -133,7 +135,7 @@ describe("sort-nav", () => {
     expect(screen.getByTestId("KeyboardArrowDownIcon")).toBeInTheDocument();
 
     // Added uses the opposite icon for asc (Up)
-    fireEvent.click(screen.getByText("Added"));
+    await user.click(screen.getByText("Added"));
     expect(screen.getByText("Added")).toHaveAttribute(
       "data-sort",
       sortDirection.ASC

--- a/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.jsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import SplitButton from "./split-button";
 import userEvent from "@testing-library/user-event";
@@ -10,19 +10,19 @@ describe("split-button", () => {
   });
 
   it("should render the split button", ({ onPick }) => {
-    const { getByRole, getByLabelText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    expect(getByRole("button", { name: "Pick A Movie" })).toBeInTheDocument();
-    expect(getByLabelText("Pick Menu")).toBeInTheDocument();
+    render(<SplitButton onPick={onPick} />);
+    expect(
+      screen.getByRole("button", { name: "Pick A Movie" })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Pick Menu")).toBeInTheDocument();
   });
 
   it("should call onPick when the main button is pressed", async ({
     onPick,
     user,
   }) => {
-    const { getByRole } = render(<SplitButton onPick={onPick} />);
-    await user.click(getByRole("button", { name: "Pick A Movie" }));
+    render(<SplitButton onPick={onPick} />);
+    await user.click(screen.getByRole("button", { name: "Pick A Movie" }));
     expect(onPick).toHaveBeenCalled();
   });
 
@@ -30,16 +30,14 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, findByText, queryByText } = render(
-      <SplitButton onPick={onPick} />
-    );
+    render(<SplitButton onPick={onPick} />);
 
-    await user.click(getByLabelText("Pick Menu"));
-    expect(await findByText(/short/i)).toBeInTheDocument();
+    await user.click(screen.getByLabelText("Pick Menu"));
+    expect(await screen.findByText(/short/i)).toBeInTheDocument();
 
-    await user.click(getByLabelText("Pick Menu"));
+    await user.click(screen.getByLabelText("Pick Menu"));
     await waitFor(() => {
-      expect(queryByText(/short/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/short/i)).not.toBeInTheDocument();
     });
   });
 
@@ -47,16 +45,14 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, findByText, queryByText } = render(
-      <SplitButton onPick={onPick} />
-    );
+    render(<SplitButton onPick={onPick} />);
 
-    await user.click(getByLabelText("Pick Menu"));
-    expect(await findByText(/short/i)).toBeInTheDocument();
+    await user.click(screen.getByLabelText("Pick Menu"));
+    expect(await screen.findByText(/short/i)).toBeInTheDocument();
 
     await user.click(document.body);
     await waitFor(() => {
-      expect(queryByText(/short/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/short/i)).not.toBeInTheDocument();
     });
   });
 
@@ -64,14 +60,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const shortButton = getByText(/pick a short movie/i);
+    const shortButton = screen.getByText(/pick a short movie/i);
     expect(shortButton).toBeInTheDocument();
     await user.click(shortButton);
     expect(onPick).toBeCalledWith({ maxRuntime: 6000 });
@@ -81,14 +75,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const regularButton = getByText(/pick a regular movie/i);
+    const regularButton = screen.getByText(/pick a regular movie/i);
     expect(regularButton).toBeInTheDocument();
     await user.click(regularButton);
     expect(onPick).toBeCalledWith({ minRuntime: 6001, maxRuntime: 7800 });
@@ -98,14 +90,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const longButton = getByText(/pick a long movie/i);
+    const longButton = screen.getByText(/pick a long movie/i);
     expect(longButton).toBeInTheDocument();
     await user.click(longButton);
     expect(onPick).toBeCalledWith({ minRuntime: 7801 });
@@ -115,14 +105,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const longButton = getByText(/added this month/i);
+    const longButton = screen.getByText(/added this month/i);
     expect(longButton).toBeInTheDocument();
     await user.click(longButton);
     expect(onPick).toBeCalledWith({ maxAdded: 30 });
@@ -132,14 +120,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const longButton = getByText(/added within 90 days/i);
+    const longButton = screen.getByText(/added within 90 days/i);
     expect(longButton).toBeInTheDocument();
     await user.click(longButton);
     expect(onPick).toBeCalledWith({ maxAdded: 90 });
@@ -149,14 +135,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const longButton = getByText(/added within a year/i);
+    const longButton = screen.getByText(/added within a year/i);
     expect(longButton).toBeInTheDocument();
     await user.click(longButton);
     expect(onPick).toBeCalledWith({ maxAdded: 365 });
@@ -166,14 +150,12 @@ describe("split-button", () => {
     onPick,
     user,
   }) => {
-    const { getByLabelText, getByText } = render(
-      <SplitButton onPick={onPick} />
-    );
-    const menuButton = getByLabelText("Pick Menu");
+    render(<SplitButton onPick={onPick} />);
+    const menuButton = screen.getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
     await user.click(menuButton);
 
-    const longButton = getByText(/added long ago/i);
+    const longButton = screen.getByText(/added long ago/i);
     expect(longButton).toBeInTheDocument();
     await user.click(longButton);
     expect(onPick).toBeCalledWith({ minAdded: 365 });

--- a/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.jsx
@@ -1,164 +1,181 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import SplitButton from "./split-button";
+import userEvent from "@testing-library/user-event";
 
 describe("split-button", () => {
-  let test;
-
-  beforeEach(() => {
-    test = {
-      onPick: vi.fn(),
-    };
+  beforeEach((context) => {
+    context.onPick = vi.fn();
+    context.user = userEvent.setup();
   });
 
-  it("should render the split button", () => {
+  it("should render the split button", ({ onPick }) => {
     const { getByRole, getByLabelText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     expect(getByRole("button", { name: "Pick A Movie" })).toBeInTheDocument();
     expect(getByLabelText("Pick Menu")).toBeInTheDocument();
   });
 
-  it("should call onPick when the main button is pressed", () => {
-    const { getByRole } = render(<SplitButton onPick={test.onPick} />);
-    fireEvent.click(getByRole("button", { name: "Pick A Movie" }));
-    expect(test.onPick).toHaveBeenCalled();
+  it("should call onPick when the main button is pressed", async ({
+    onPick,
+    user,
+  }) => {
+    const { getByRole } = render(<SplitButton onPick={onPick} />);
+    await user.click(getByRole("button", { name: "Pick A Movie" }));
+    expect(onPick).toHaveBeenCalled();
   });
 
-  it("should open and close the menu when the menu button is pressed", async () => {
-    const { getByLabelText, getByText, queryByText } = render(
-      <SplitButton onPick={test.onPick} />
+  it("should open and close the menu when the menu button is pressed", async ({
+    onPick,
+    user,
+  }) => {
+    const { getByLabelText, findByText, queryByText } = render(
+      <SplitButton onPick={onPick} />
     );
-    fireEvent.click(getByLabelText("Pick Menu"));
-    await waitFor(() => {
-      expect(getByText(/short/i)).toBeInTheDocument();
-    });
 
-    // Couldn't figure out a better way to make this work.
-    // Even using waitFor, firing click twice without a sleep ends up firing it twice at once and ends up acting like a single click.
-    await new Promise((r) => setTimeout(r, 1));
+    await user.click(getByLabelText("Pick Menu"));
+    expect(await findByText(/short/i)).toBeInTheDocument();
 
-    fireEvent.click(getByLabelText("Pick Menu"));
+    await user.click(getByLabelText("Pick Menu"));
     await waitFor(() => {
       expect(queryByText(/short/i)).not.toBeInTheDocument();
     });
   });
 
-  it("should close the menu when clicking outside", async () => {
-    const { getByLabelText, getByText, queryByText } = render(
-      <SplitButton onPick={test.onPick} />
+  it("should close the menu when clicking outside", async ({
+    onPick,
+    user,
+  }) => {
+    const { getByLabelText, findByText, queryByText } = render(
+      <SplitButton onPick={onPick} />
     );
 
-    fireEvent.click(getByLabelText("Pick Menu"));
-    await waitFor(() => {
-      expect(getByText(/short/i)).toBeInTheDocument();
-    });
+    await user.click(getByLabelText("Pick Menu"));
+    expect(await findByText(/short/i)).toBeInTheDocument();
 
-    // Couldn't figure out a better way to make this work.
-    // Even using waitFor, firing click twice without a sleep ends up firing it twice at once and ends up acting like a single click.
-    await new Promise((r) => setTimeout(r, 1));
-
-    fireEvent.click(document);
+    await user.click(document.body);
     await waitFor(() => {
       expect(queryByText(/short/i)).not.toBeInTheDocument();
     });
   });
 
-  it("should call onPick with correct options when a short movie is requested", () => {
+  it("should call onPick with correct options when a short movie is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const shortButton = getByText(/pick a short movie/i);
     expect(shortButton).toBeInTheDocument();
-    fireEvent.click(shortButton);
-    expect(test.onPick).toBeCalledWith({ maxRuntime: 6000 });
+    await user.click(shortButton);
+    expect(onPick).toBeCalledWith({ maxRuntime: 6000 });
   });
 
-  it("should call onPick with correct options when a regular movie is requested", () => {
+  it("should call onPick with correct options when a regular movie is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const regularButton = getByText(/pick a regular movie/i);
     expect(regularButton).toBeInTheDocument();
-    fireEvent.click(regularButton);
-    expect(test.onPick).toBeCalledWith({ minRuntime: 6001, maxRuntime: 7800 });
+    await user.click(regularButton);
+    expect(onPick).toBeCalledWith({ minRuntime: 6001, maxRuntime: 7800 });
   });
 
-  it("should call onPick with correct options when a long movie is requested", () => {
+  it("should call onPick with correct options when a long movie is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const longButton = getByText(/pick a long movie/i);
     expect(longButton).toBeInTheDocument();
-    fireEvent.click(longButton);
-    expect(test.onPick).toBeCalledWith({ minRuntime: 7801 });
+    await user.click(longButton);
+    expect(onPick).toBeCalledWith({ minRuntime: 7801 });
   });
 
-  it("should call onPick with correct options when a movie added this month is requested", () => {
+  it("should call onPick with correct options when a movie added this month is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const longButton = getByText(/added this month/i);
     expect(longButton).toBeInTheDocument();
-    fireEvent.click(longButton);
-    expect(test.onPick).toBeCalledWith({ maxAdded: 30 });
+    await user.click(longButton);
+    expect(onPick).toBeCalledWith({ maxAdded: 30 });
   });
 
-  it("should call onPick with correct options when a movie added within 90 days is requested", () => {
+  it("should call onPick with correct options when a movie added within 90 days is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const longButton = getByText(/added within 90 days/i);
     expect(longButton).toBeInTheDocument();
-    fireEvent.click(longButton);
-    expect(test.onPick).toBeCalledWith({ maxAdded: 90 });
+    await user.click(longButton);
+    expect(onPick).toBeCalledWith({ maxAdded: 90 });
   });
 
-  it("should call onPick with correct options when a movie added within a year is requested", () => {
+  it("should call onPick with correct options when a movie added within a year is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const longButton = getByText(/added within a year/i);
     expect(longButton).toBeInTheDocument();
-    fireEvent.click(longButton);
-    expect(test.onPick).toBeCalledWith({ maxAdded: 365 });
+    await user.click(longButton);
+    expect(onPick).toBeCalledWith({ maxAdded: 365 });
   });
 
-  it("should call onPick with correct options when a movie added long ago is requested", () => {
+  it("should call onPick with correct options when a movie added long ago is requested", async ({
+    onPick,
+    user,
+  }) => {
     const { getByLabelText, getByText } = render(
-      <SplitButton onPick={test.onPick} />
+      <SplitButton onPick={onPick} />
     );
     const menuButton = getByLabelText("Pick Menu");
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
 
     const longButton = getByText(/added long ago/i);
     expect(longButton).toBeInTheDocument();
-    fireEvent.click(longButton);
-    expect(test.onPick).toBeCalledWith({ minAdded: 365 });
+    await user.click(longButton);
+    expect(onPick).toBeCalledWith({ minAdded: 365 });
   });
 });

--- a/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.jsx
@@ -1,12 +1,10 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import SplitButton from "./split-button";
-import userEvent from "@testing-library/user-event";
 
 describe("split-button", () => {
   beforeEach((context) => {
     context.onPick = vi.fn();
-    context.user = userEvent.setup();
   });
 
   it("should render the split button", ({ onPick }) => {

--- a/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import EmptyList from "./empty-list";
 import { vi } from "vitest";
 
@@ -9,11 +9,11 @@ describe("empty-list", () => {
     };
   });
 
-  it("should render the edit button", ({ props }) => {
+  it("should render the edit button", async ({ props, user }) => {
     render(<EmptyList {...props} />);
     const button = screen.getByRole("button", { name: "Add a Movie" });
     expect(button).toBeInTheDocument();
-    fireEvent.click(button);
+    await user.click(button);
     expect(props.onAddMovie).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import EmptyList from "./empty-list";
 import { vi } from "vitest";
 
@@ -10,8 +10,8 @@ describe("empty-list", () => {
   });
 
   it("should render the edit button", ({ props }) => {
-    const { getByRole } = render(<EmptyList {...props} />);
-    const button = getByRole("button", { name: "Add a Movie" });
+    render(<EmptyList {...props} />);
+    const button = screen.getByRole("button", { name: "Add a Movie" });
     expect(button).toBeInTheDocument();
     fireEvent.click(button);
     expect(props.onAddMovie).toHaveBeenCalled();

--- a/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.test.jsx
@@ -3,15 +3,13 @@ import EmptyList from "./empty-list";
 import { vi } from "vitest";
 
 describe("empty-list", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       onAddMovie: vi.fn(),
     };
   });
 
-  it("should render the edit button", () => {
+  it("should render the edit button", ({ props }) => {
     const { getByRole } = render(<EmptyList {...props} />);
     const button = getByRole("button", { name: "Add a Movie" });
     expect(button).toBeInTheDocument();

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.jsx
@@ -14,10 +14,8 @@ vi.mock("../movie/movie", () => ({
 }));
 
 describe("movie-section", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       title: "Test Title",
       subtitle: "My Subtitle",
       list: [
@@ -32,7 +30,7 @@ describe("movie-section", () => {
     };
   });
 
-  it("should render the section and assing handlers", () => {
+  it("should render the section and assing handlers", ({ props }) => {
     const { getByText, getByRole } = render(<MovieSection {...props} />);
 
     expect(getByText("Test Title")).toBeInTheDocument();
@@ -49,7 +47,9 @@ describe("movie-section", () => {
     expect(props.onDeleteMovie).toHaveBeenCalled();
   });
 
-  it("should not render the title and subtitle when the title is omitted", () => {
+  it("should not render the title and subtitle when the title is omitted", ({
+    props,
+  }) => {
     const { getByText, queryByText } = render(
       <MovieSection {...props} title={undefined} />
     );
@@ -59,7 +59,7 @@ describe("movie-section", () => {
     expect(getByText("Movie #1")).toBeInTheDocument();
   });
 
-  it("should not render the subtitle when omitted", () => {
+  it("should not render the subtitle when omitted", ({ props }) => {
     const { getByText, queryByText } = render(
       <MovieSection {...props} subtitle={undefined} />
     );

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import MovieSection from "./movie-section";
 import { vi } from "vitest";
 
@@ -30,20 +30,23 @@ describe("movie-section", () => {
     };
   });
 
-  it("should render the section and assing handlers", ({ props }) => {
+  it("should render the section and assing handlers", async ({
+    props,
+    user,
+  }) => {
     render(<MovieSection {...props} />);
 
     expect(screen.getByText("Test Title")).toBeInTheDocument();
     expect(screen.getByText("My Subtitle")).toBeInTheDocument();
     expect(screen.getByText("Movie #1")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Edit" }));
     expect(props.onEditMovie).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Mark Watched" }));
+    await user.click(screen.getByRole("button", { name: "Mark Watched" }));
     expect(props.onMarkWatched).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
     expect(props.onDeleteMovie).toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import MovieSection from "./movie-section";
 import { vi } from "vitest";
 
@@ -31,41 +31,37 @@ describe("movie-section", () => {
   });
 
   it("should render the section and assing handlers", ({ props }) => {
-    const { getByText, getByRole } = render(<MovieSection {...props} />);
+    render(<MovieSection {...props} />);
 
-    expect(getByText("Test Title")).toBeInTheDocument();
-    expect(getByText("My Subtitle")).toBeInTheDocument();
-    expect(getByText("Movie #1")).toBeInTheDocument();
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("My Subtitle")).toBeInTheDocument();
+    expect(screen.getByText("Movie #1")).toBeInTheDocument();
 
-    fireEvent.click(getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     expect(props.onEditMovie).toHaveBeenCalled();
 
-    fireEvent.click(getByRole("button", { name: "Mark Watched" }));
+    fireEvent.click(screen.getByRole("button", { name: "Mark Watched" }));
     expect(props.onMarkWatched).toHaveBeenCalled();
 
-    fireEvent.click(getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(props.onDeleteMovie).toHaveBeenCalled();
   });
 
   it("should not render the title and subtitle when the title is omitted", ({
     props,
   }) => {
-    const { getByText, queryByText } = render(
-      <MovieSection {...props} title={undefined} />
-    );
+    render(<MovieSection {...props} title={undefined} />);
 
-    expect(queryByText("Test Title")).not.toBeInTheDocument();
-    expect(queryByText("My Subtitle")).not.toBeInTheDocument();
-    expect(getByText("Movie #1")).toBeInTheDocument();
+    expect(screen.queryByText("Test Title")).not.toBeInTheDocument();
+    expect(screen.queryByText("My Subtitle")).not.toBeInTheDocument();
+    expect(screen.getByText("Movie #1")).toBeInTheDocument();
   });
 
   it("should not render the subtitle when omitted", ({ props }) => {
-    const { getByText, queryByText } = render(
-      <MovieSection {...props} subtitle={undefined} />
-    );
+    render(<MovieSection {...props} subtitle={undefined} />);
 
-    expect(getByText("Test Title")).toBeInTheDocument();
-    expect(queryByText("My Subtitle")).not.toBeInTheDocument();
-    expect(getByText("Movie #1")).toBeInTheDocument();
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.queryByText("My Subtitle")).not.toBeInTheDocument();
+    expect(screen.getByText("Movie #1")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import DetailActions from "./detail-actions";
 import { vi } from "vitest";
 
@@ -18,39 +18,39 @@ describe("detail-actions", () => {
   });
 
   it("should render the edit button", () => {
-    const { getByLabelText } = render(<DetailActions {...props} />);
-    expect(getByLabelText("Edit")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Edit"));
+    render(<DetailActions {...props} />);
+    expect(screen.getByLabelText("Edit")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Edit"));
     expect(props.onEdit).toHaveBeenCalled();
   });
 
   it("should render the mark watched button", () => {
-    const { getByLabelText } = render(<DetailActions {...props} />);
-    expect(getByLabelText("Mark as Watched")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Mark as Watched"));
+    render(<DetailActions {...props} />);
+    expect(screen.getByLabelText("Mark as Watched")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Mark as Watched"));
     expect(props.onMarkWatched).toHaveBeenCalled();
   });
 
   it("should render the mark delete button", () => {
-    const { getByLabelText } = render(<DetailActions {...props} />);
-    expect(getByLabelText("Delete")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Delete"));
+    render(<DetailActions {...props} />);
+    expect(screen.getByLabelText("Delete")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Delete"));
     expect(props.onDelete).toHaveBeenCalled();
   });
 
   it("should render the locked button with the lock icon when in the unlocked state", () => {
-    const { getByLabelText } = render(<DetailActions {...props} />);
-    expect(getByLabelText("Lock")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Lock"));
+    render(<DetailActions {...props} />);
+    expect(screen.getByLabelText("Lock")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Lock"));
     expect(props.onToggleLock).toHaveBeenCalledWith(true);
   });
 
   it("should render the locked button with the unlock icon when in the locked state", () => {
-    const { getByLabelText } = render(
+    render(
       <DetailActions {...props} movie={{ ...props.movie, locked: true }} />
     );
-    expect(getByLabelText("Unlock")).toBeInTheDocument();
-    fireEvent.click(getByLabelText("Unlock"));
+    expect(screen.getByLabelText("Unlock")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Unlock"));
     expect(props.onToggleLock).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import DetailActions from "./detail-actions";
 import { vi } from "vitest";
 
@@ -17,40 +17,44 @@ describe("detail-actions", () => {
     };
   });
 
-  it("should render the edit button", () => {
+  it("should render the edit button", async ({ user }) => {
     render(<DetailActions {...props} />);
     expect(screen.getByLabelText("Edit")).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText("Edit"));
+    await user.click(screen.getByLabelText("Edit"));
     expect(props.onEdit).toHaveBeenCalled();
   });
 
-  it("should render the mark watched button", () => {
+  it("should render the mark watched button", async ({ user }) => {
     render(<DetailActions {...props} />);
     expect(screen.getByLabelText("Mark as Watched")).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText("Mark as Watched"));
+    await user.click(screen.getByLabelText("Mark as Watched"));
     expect(props.onMarkWatched).toHaveBeenCalled();
   });
 
-  it("should render the mark delete button", () => {
+  it("should render the mark delete button", async ({ user }) => {
     render(<DetailActions {...props} />);
     expect(screen.getByLabelText("Delete")).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText("Delete"));
+    await user.click(screen.getByLabelText("Delete"));
     expect(props.onDelete).toHaveBeenCalled();
   });
 
-  it("should render the locked button with the lock icon when in the unlocked state", () => {
+  it("should render the locked button with the lock icon when in the unlocked state", async ({
+    user,
+  }) => {
     render(<DetailActions {...props} />);
     expect(screen.getByLabelText("Lock")).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText("Lock"));
+    await user.click(screen.getByLabelText("Lock"));
     expect(props.onToggleLock).toHaveBeenCalledWith(true);
   });
 
-  it("should render the locked button with the unlock icon when in the locked state", () => {
+  it("should render the locked button with the unlock icon when in the locked state", async ({
+    user,
+  }) => {
     render(
       <DetailActions {...props} movie={{ ...props.movie, locked: true }} />
     );
     expect(screen.getByLabelText("Unlock")).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText("Unlock"));
+    await user.click(screen.getByLabelText("Unlock"));
     expect(props.onToggleLock).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/expanded/expanded.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/expanded/expanded.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Expanded from "./expanded";
 import { vi } from "vitest";
 
@@ -27,40 +27,34 @@ describe("expanded", () => {
   });
 
   it("should not render the full detail mock or backdrop when open and preload are false", () => {
-    const { queryByLabelText, queryByTestId } = render(<Expanded {...props} />);
-    expect(queryByLabelText("fullDetailMock")).not.toBeInTheDocument();
-    expect(queryByTestId("backdrop")).not.toBeInTheDocument();
+    render(<Expanded {...props} />);
+    expect(screen.queryByLabelText("fullDetailMock")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("backdrop")).not.toBeInTheDocument();
   });
 
   it("should render the full detail mock and backdrop when open is true", () => {
-    const { getByLabelText, getByTestId } = render(
-      <Expanded {...props} open={true} />
-    );
-    expect(getByLabelText("fullDetailMock")).toBeInTheDocument();
-    expect(getByTestId("backdrop")).toBeInTheDocument();
+    render(<Expanded {...props} open={true} />);
+    expect(screen.getByLabelText("fullDetailMock")).toBeInTheDocument();
+    expect(screen.getByTestId("backdrop")).toBeInTheDocument();
   });
 
   it("should render the full detail mock but not the backdrop when preload is true", () => {
-    const { getByLabelText, queryByTestId } = render(
-      <Expanded {...props} preload={true} />
-    );
-    expect(getByLabelText("fullDetailMock")).toBeInTheDocument();
-    expect(queryByTestId("backdrop")).not.toBeInTheDocument();
+    render(<Expanded {...props} preload={true} />);
+    expect(screen.getByLabelText("fullDetailMock")).toBeInTheDocument();
+    expect(screen.queryByTestId("backdrop")).not.toBeInTheDocument();
   });
 
   it("should call onClose when clicking on the backdrop", async () => {
-    const { getByTestId } = render(<Expanded {...props} open={true} />);
-    expect(getByTestId("backdrop")).toBeInTheDocument();
-    fireEvent.click(getByTestId("backdrop"));
+    render(<Expanded {...props} open={true} />);
+    expect(screen.getByTestId("backdrop")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("backdrop"));
     expect(props.onClose).toHaveBeenCalled();
   });
 
   it("should call onClose when clicking on the full detail close button", async () => {
-    const { getByLabelText, getByRole } = render(
-      <Expanded {...props} open={true} />
-    );
-    expect(getByLabelText("fullDetailMock")).toBeInTheDocument();
-    fireEvent.click(getByRole("button", { name: "Close" }));
+    render(<Expanded {...props} open={true} />);
+    expect(screen.getByLabelText("fullDetailMock")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(onCloseMock).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/expanded/expanded.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/expanded/expanded.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Expanded from "./expanded";
 import { vi } from "vitest";
 
@@ -44,17 +44,19 @@ describe("expanded", () => {
     expect(screen.queryByTestId("backdrop")).not.toBeInTheDocument();
   });
 
-  it("should call onClose when clicking on the backdrop", async () => {
+  it("should call onClose when clicking on the backdrop", async ({ user }) => {
     render(<Expanded {...props} open={true} />);
     expect(screen.getByTestId("backdrop")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("backdrop"));
+    await user.click(screen.getByTestId("backdrop"));
     expect(props.onClose).toHaveBeenCalled();
   });
 
-  it("should call onClose when clicking on the full detail close button", async () => {
+  it("should call onClose when clicking on the full detail close button", async ({
+    user,
+  }) => {
     render(<Expanded {...props} open={true} />);
     expect(screen.getByLabelText("fullDetailMock")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await user.click(screen.getByRole("button", { name: "Close" }));
     expect(onCloseMock).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/source/source.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/source/source.test.jsx
@@ -1,13 +1,13 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { sources } from "md4k-constants";
 import { sourceLogos } from "../../../../../../../../../../constants/sources";
 import Source from "./source";
 
 describe("empty-list", () => {
   it("should render the correct source and logo", () => {
-    const { getByLabelText } = render(<Source source={sources.NETFLIX} />);
-    expect(getByLabelText("Netflix")).toBeInTheDocument();
-    expect(getByLabelText("Netflix")).toHaveStyle(
+    render(<Source source={sources.NETFLIX} />);
+    expect(screen.getByLabelText("Netflix")).toBeInTheDocument();
+    expect(screen.getByLabelText("Netflix")).toHaveStyle(
       `background-image: url(${sourceLogos[sources.NETFLIX]})`
     );
   });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.styles.js
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.styles.js
@@ -25,7 +25,7 @@ export const MovieDetailPositioner = styled("div")(() => ({
   bottom: 0,
   left: 0,
   right: 0,
-  pointerEvents: "none",
+  // pointerEvents: "none",
   opacity: 0,
 }));
 
@@ -89,6 +89,7 @@ export const InfoFooterLayout = styled(animated.div)`
 export const StarRatingLayout = styled("div")`
   grid-area: rating;
   filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));
+  pointer-events: "auto";
 `;
 
 export const SourceLayout = styled("div")(({ theme: { spacing } }) => ({

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
@@ -63,7 +63,7 @@ describe("movie", () => {
       getByAltText,
       getAllByAltText,
       getByText,
-    } = await renderWithProviders(<Movie {...props} />);
+    } = renderWithProviders(<Movie {...props} />);
 
     // Should be two posters, the second is the larger overlaid one that is wrapped in an invisible div
     expect(getAllByLabelText(/Bourne.*Poster/)).toHaveLength(2);
@@ -91,7 +91,7 @@ describe("movie", () => {
   });
 
   it("should render a movie list entry as locked", async () => {
-    const { getByLabelText } = await renderWithProviders(
+    const { getByLabelText } = renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );
 
@@ -99,7 +99,7 @@ describe("movie", () => {
   });
 
   it("should open the zoomed poster and preload the expanded detail on rollover and close the zoomed poster on rollout", async () => {
-    const { getByTestId, getByText } = await renderWithProviders(
+    const { getByTestId, getByText } = renderWithProviders(
       <Movie {...props} />
     );
 
@@ -117,7 +117,7 @@ describe("movie", () => {
   });
 
   it("should close the zoomed poster and open the expanded detail view when clicked", async () => {
-    const { getByTestId, getByText } = await renderWithProviders(
+    const { getByTestId, getByText } = renderWithProviders(
       <Movie {...props} />
     );
 
@@ -134,7 +134,7 @@ describe("movie", () => {
   });
 
   it("should toggle the actions and ratings when mousing over the five star rating", async () => {
-    const { getByTestId } = await renderWithProviders(<Movie {...props} />);
+    const { getByTestId } = renderWithProviders(<Movie {...props} />);
 
     expect(getByTestId("actions")).toHaveStyle({
       transform: "translateX(0px)",
@@ -167,7 +167,7 @@ describe("movie", () => {
   });
 
   it("should toggle the actions and ratings when clicking the five star rating", async () => {
-    const { getByTestId } = await renderWithProviders(<Movie {...props} />);
+    const { getByTestId } = renderWithProviders(<Movie {...props} />);
 
     expect(getByTestId("actions")).toHaveStyle({
       transform: "translateX(0px)",
@@ -200,7 +200,7 @@ describe("movie", () => {
   });
 
   it("should send the edit action and close the zoomed view", async () => {
-    const { getByLabelText, getByTestId } = await renderWithProviders(
+    const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
     fireEvent.click(getByLabelText("Edit"));
@@ -211,7 +211,7 @@ describe("movie", () => {
   });
 
   it("should send the mark watched action and close the zoomed view", async () => {
-    const { getByLabelText, getByTestId } = await renderWithProviders(
+    const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
     fireEvent.click(getByLabelText("Mark as Watched"));
@@ -222,7 +222,7 @@ describe("movie", () => {
   });
 
   it("should send the delete action and close the zoomed view", async () => {
-    const { getByLabelText, getByTestId } = await renderWithProviders(
+    const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
     fireEvent.click(getByLabelText("Delete"));
@@ -233,7 +233,7 @@ describe("movie", () => {
   });
 
   it("should send the edit action with locked:true and close the zoomed view", async () => {
-    const { getByLabelText, getByTestId } = await renderWithProviders(
+    const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
     fireEvent.click(getByLabelText("Lock"));
@@ -250,7 +250,7 @@ describe("movie", () => {
   });
 
   it("should send the edit action with locked:false and close the zoomed view", async () => {
-    const { getByLabelText, getByTestId } = await renderWithProviders(
+    const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );
     fireEvent.click(getByLabelText("Unlock"));

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
@@ -53,7 +53,7 @@ describe("movie", () => {
     };
   });
 
-  it("should render a movie list entry", async ({ props }) => {
+  it("should render a movie list entry", ({ props }) => {
     renderWithProviders(<Movie {...props} />);
 
     // Should be two posters, the second is the larger overlaid one that is wrapped in an invisible div
@@ -81,7 +81,7 @@ describe("movie", () => {
     expect(screen.getByText("Expanded")).toHaveAttribute("data-open", "false");
   });
 
-  it("should render a movie list entry as locked", async ({ props }) => {
+  it("should render a movie list entry as locked", ({ props }) => {
     renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor, screen } from "@testing-library/react";
+import { waitFor, screen } from "@testing-library/react";
 import Movie from "./movie";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../../../utils/render-with-providers";
@@ -91,10 +91,11 @@ describe("movie", () => {
 
   it("should open the zoomed poster and preload the expanded detail on rollover and close the zoomed poster on rollout", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
 
-    fireEvent.mouseOver(screen.getByTestId("listItem"));
+    await user.hover(screen.getByTestId("listItem"));
     await waitFor(() => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 });
       expect(screen.getByText("Expanded")).toHaveAttribute(
@@ -103,7 +104,7 @@ describe("movie", () => {
       );
     });
 
-    fireEvent.mouseOut(screen.getByTestId("listItem"));
+    await user.unhover(screen.getByTestId("listItem"));
     await waitFor(() => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 });
       expect(screen.getByText("Expanded")).toHaveAttribute(
@@ -115,15 +116,17 @@ describe("movie", () => {
 
   it("should close the zoomed poster and open the expanded detail view when clicked", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
 
-    fireEvent.mouseOver(screen.getByTestId("listItem"));
+    await user.hover(screen.getByTestId("listItem"));
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(screen.getByTestId("positioner"));
+    await user.click(screen.getByTestId("positioner"));
+
     await waitFor(() => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 });
       expect(screen.getByText("Expanded")).toHaveAttribute("data-open", "true");
@@ -132,6 +135,7 @@ describe("movie", () => {
 
   it("should toggle the actions and ratings when mousing over the five star rating", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
 
@@ -142,7 +146,7 @@ describe("movie", () => {
       transform: "translateX(0px)",
     });
 
-    fireEvent.mouseOver(screen.getByTestId("rating"));
+    await user.hover(screen.getByTestId("rating"));
 
     await waitFor(() => {
       expect(screen.getByTestId("actions")).not.toHaveStyle({
@@ -153,7 +157,7 @@ describe("movie", () => {
       });
     });
 
-    fireEvent.mouseOut(screen.getByTestId("rating"));
+    await user.unhover(screen.getByTestId("rating"));
 
     await waitFor(() => {
       expect(screen.getByTestId("actions")).toHaveStyle({
@@ -167,6 +171,7 @@ describe("movie", () => {
 
   it("should toggle the actions and ratings when clicking the five star rating", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
 
@@ -177,7 +182,7 @@ describe("movie", () => {
       transform: "translateX(0px)",
     });
 
-    fireEvent.click(screen.getByTestId("rating"));
+    await user.click(screen.getByTestId("rating"));
 
     await waitFor(() => {
       expect(screen.getByTestId("actions")).not.toHaveStyle({
@@ -188,7 +193,7 @@ describe("movie", () => {
       });
     });
 
-    fireEvent.click(screen.getByTestId("rating"));
+    await user.click(screen.getByTestId("rating"));
 
     await waitFor(() => {
       expect(screen.getByTestId("actions")).toHaveStyle({
@@ -202,9 +207,10 @@ describe("movie", () => {
 
   it("should send the edit action and close the zoomed view", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
-    fireEvent.click(screen.getByLabelText("Edit"));
+    await user.click(screen.getByLabelText("Edit"));
     expect(props.onEditMovie).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
@@ -213,9 +219,10 @@ describe("movie", () => {
 
   it("should send the mark watched action and close the zoomed view", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
-    fireEvent.click(screen.getByLabelText("Mark as Watched"));
+    await user.click(screen.getByLabelText("Mark as Watched"));
     expect(props.onMarkWatched).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
@@ -224,9 +231,10 @@ describe("movie", () => {
 
   it("should send the delete action and close the zoomed view", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
-    fireEvent.click(screen.getByLabelText("Delete"));
+    await user.click(screen.getByLabelText("Delete"));
     expect(props.onDeleteMovie).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
@@ -235,9 +243,10 @@ describe("movie", () => {
 
   it("should send the edit action with locked:true and close the zoomed view", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<Movie {...props} />);
-    fireEvent.click(screen.getByLabelText("Lock"));
+    await user.click(screen.getByLabelText("Lock"));
     expect(props.onEditMovie).toHaveBeenCalledWith(
       {
         ...props.movie,
@@ -252,11 +261,12 @@ describe("movie", () => {
 
   it("should send the edit action with locked:false and close the zoomed view", async ({
     props,
+    user,
   }) => {
     renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );
-    fireEvent.click(screen.getByLabelText("Unlock"));
+    await user.click(screen.getByLabelText("Unlock"));
     expect(props.onEditMovie).toHaveBeenCalledWith(
       {
         ...props.movie,

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
@@ -24,10 +24,8 @@ vi.mock("./components/expanded/expanded", () => ({
 }));
 
 describe("movie", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movie: {
         id: "8502fd8b-165e-4239-965f-b46f8d523829",
         title: "The Bourne Identity",
@@ -55,7 +53,7 @@ describe("movie", () => {
     };
   });
 
-  it("should render a movie list entry", async () => {
+  it("should render a movie list entry", async ({ props }) => {
     const {
       getByTestId,
       getByLabelText,
@@ -90,7 +88,7 @@ describe("movie", () => {
     expect(getByText("Expanded")).toHaveAttribute("data-open", "false");
   });
 
-  it("should render a movie list entry as locked", async () => {
+  it("should render a movie list entry as locked", async ({ props }) => {
     const { getByLabelText } = renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );
@@ -98,7 +96,9 @@ describe("movie", () => {
     expect(getByLabelText("Unlock")).toBeInTheDocument();
   });
 
-  it("should open the zoomed poster and preload the expanded detail on rollover and close the zoomed poster on rollout", async () => {
+  it("should open the zoomed poster and preload the expanded detail on rollover and close the zoomed poster on rollout", async ({
+    props,
+  }) => {
     const { getByTestId, getByText } = renderWithProviders(
       <Movie {...props} />
     );
@@ -116,7 +116,9 @@ describe("movie", () => {
     });
   });
 
-  it("should close the zoomed poster and open the expanded detail view when clicked", async () => {
+  it("should close the zoomed poster and open the expanded detail view when clicked", async ({
+    props,
+  }) => {
     const { getByTestId, getByText } = renderWithProviders(
       <Movie {...props} />
     );
@@ -133,7 +135,9 @@ describe("movie", () => {
     });
   });
 
-  it("should toggle the actions and ratings when mousing over the five star rating", async () => {
+  it("should toggle the actions and ratings when mousing over the five star rating", async ({
+    props,
+  }) => {
     const { getByTestId } = renderWithProviders(<Movie {...props} />);
 
     expect(getByTestId("actions")).toHaveStyle({
@@ -166,7 +170,9 @@ describe("movie", () => {
     });
   });
 
-  it("should toggle the actions and ratings when clicking the five star rating", async () => {
+  it("should toggle the actions and ratings when clicking the five star rating", async ({
+    props,
+  }) => {
     const { getByTestId } = renderWithProviders(<Movie {...props} />);
 
     expect(getByTestId("actions")).toHaveStyle({
@@ -199,7 +205,9 @@ describe("movie", () => {
     });
   });
 
-  it("should send the edit action and close the zoomed view", async () => {
+  it("should send the edit action and close the zoomed view", async ({
+    props,
+  }) => {
     const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
@@ -210,7 +218,9 @@ describe("movie", () => {
     );
   });
 
-  it("should send the mark watched action and close the zoomed view", async () => {
+  it("should send the mark watched action and close the zoomed view", async ({
+    props,
+  }) => {
     const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
@@ -221,7 +231,9 @@ describe("movie", () => {
     );
   });
 
-  it("should send the delete action and close the zoomed view", async () => {
+  it("should send the delete action and close the zoomed view", async ({
+    props,
+  }) => {
     const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
@@ -232,7 +244,9 @@ describe("movie", () => {
     );
   });
 
-  it("should send the edit action with locked:true and close the zoomed view", async () => {
+  it("should send the edit action with locked:true and close the zoomed view", async ({
+    props,
+  }) => {
     const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} />
     );
@@ -249,7 +263,9 @@ describe("movie", () => {
     );
   });
 
-  it("should send the edit action with locked:false and close the zoomed view", async () => {
+  it("should send the edit action with locked:false and close the zoomed view", async ({
+    props,
+  }) => {
     const { getByLabelText, getByTestId } = renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, waitFor, screen } from "@testing-library/react";
 import Movie from "./movie";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../../../utils/render-with-providers";
@@ -54,117 +54,112 @@ describe("movie", () => {
   });
 
   it("should render a movie list entry", async ({ props }) => {
-    const {
-      getByTestId,
-      getByLabelText,
-      getAllByLabelText,
-      getByAltText,
-      getAllByAltText,
-      getByText,
-    } = renderWithProviders(<Movie {...props} />);
+    renderWithProviders(<Movie {...props} />);
 
     // Should be two posters, the second is the larger overlaid one that is wrapped in an invisible div
-    expect(getAllByLabelText(/Bourne.*Poster/)).toHaveLength(2);
+    expect(screen.getAllByLabelText(/Bourne.*Poster/)).toHaveLength(2);
 
     // The larger poster is invisible by default
-    expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 });
+    expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 });
 
     // Movie info
-    expect(getAllByAltText(/star-/)).toHaveLength(5);
-    expect(getByText("1h 59m")).toBeInTheDocument();
-    expect(getByLabelText("Edit")).toBeInTheDocument();
-    expect(getByLabelText("Mark as Watched")).toBeInTheDocument();
-    expect(getByLabelText("Lock")).toBeInTheDocument();
-    expect(getByLabelText("Delete")).toBeInTheDocument();
-    expect(getByAltText("IMDB")).toBeInTheDocument();
-    expect(getByText("79%")).toBeInTheDocument();
-    expect(getByAltText("ROTTEN_TOMATOES")).toBeInTheDocument();
-    expect(getByText("84%")).toBeInTheDocument();
-    expect(getByAltText("METACRITIC")).toBeInTheDocument();
-    expect(getByText("68%")).toBeInTheDocument();
-    expect(getByLabelText("Netflix")).toBeInTheDocument();
+    expect(screen.getAllByAltText(/star-/)).toHaveLength(5);
+    expect(screen.getByText("1h 59m")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mark as Watched")).toBeInTheDocument();
+    expect(screen.getByLabelText("Lock")).toBeInTheDocument();
+    expect(screen.getByLabelText("Delete")).toBeInTheDocument();
+    expect(screen.getByAltText("IMDB")).toBeInTheDocument();
+    expect(screen.getByText("79%")).toBeInTheDocument();
+    expect(screen.getByAltText("ROTTEN_TOMATOES")).toBeInTheDocument();
+    expect(screen.getByText("84%")).toBeInTheDocument();
+    expect(screen.getByAltText("METACRITIC")).toBeInTheDocument();
+    expect(screen.getByText("68%")).toBeInTheDocument();
+    expect(screen.getByLabelText("Netflix")).toBeInTheDocument();
 
     // The expanded detail should be closed by default
-    expect(getByText("Expanded")).toHaveAttribute("data-open", "false");
+    expect(screen.getByText("Expanded")).toHaveAttribute("data-open", "false");
   });
 
   it("should render a movie list entry as locked", async ({ props }) => {
-    const { getByLabelText } = renderWithProviders(
+    renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );
 
-    expect(getByLabelText("Unlock")).toBeInTheDocument();
+    expect(screen.getByLabelText("Unlock")).toBeInTheDocument();
   });
 
   it("should open the zoomed poster and preload the expanded detail on rollover and close the zoomed poster on rollout", async ({
     props,
   }) => {
-    const { getByTestId, getByText } = renderWithProviders(
-      <Movie {...props} />
-    );
+    renderWithProviders(<Movie {...props} />);
 
-    fireEvent.mouseOver(getByTestId("listItem"));
+    fireEvent.mouseOver(screen.getByTestId("listItem"));
     await waitFor(() => {
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 1 });
-      expect(getByText("Expanded")).toHaveAttribute("data-preload", "true");
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 });
+      expect(screen.getByText("Expanded")).toHaveAttribute(
+        "data-preload",
+        "true"
+      );
     });
 
-    fireEvent.mouseOut(getByTestId("listItem"));
+    fireEvent.mouseOut(screen.getByTestId("listItem"));
     await waitFor(() => {
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 });
-      expect(getByText("Expanded")).toHaveAttribute("data-preload", "false");
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 });
+      expect(screen.getByText("Expanded")).toHaveAttribute(
+        "data-preload",
+        "false"
+      );
     });
   });
 
   it("should close the zoomed poster and open the expanded detail view when clicked", async ({
     props,
   }) => {
-    const { getByTestId, getByText } = renderWithProviders(
-      <Movie {...props} />
-    );
+    renderWithProviders(<Movie {...props} />);
 
-    fireEvent.mouseOver(getByTestId("listItem"));
+    fireEvent.mouseOver(screen.getByTestId("listItem"));
     await waitFor(() =>
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 1 })
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(getByTestId("positioner"));
+    fireEvent.click(screen.getByTestId("positioner"));
     await waitFor(() => {
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 });
-      expect(getByText("Expanded")).toHaveAttribute("data-open", "true");
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 });
+      expect(screen.getByText("Expanded")).toHaveAttribute("data-open", "true");
     });
   });
 
   it("should toggle the actions and ratings when mousing over the five star rating", async ({
     props,
   }) => {
-    const { getByTestId } = renderWithProviders(<Movie {...props} />);
+    renderWithProviders(<Movie {...props} />);
 
-    expect(getByTestId("actions")).toHaveStyle({
+    expect(screen.getByTestId("actions")).toHaveStyle({
       transform: "translateX(0px)",
     });
-    expect(getByTestId("ratings")).not.toHaveStyle({
+    expect(screen.getByTestId("ratings")).not.toHaveStyle({
       transform: "translateX(0px)",
     });
 
-    fireEvent.mouseOver(getByTestId("rating"));
+    fireEvent.mouseOver(screen.getByTestId("rating"));
 
     await waitFor(() => {
-      expect(getByTestId("actions")).not.toHaveStyle({
+      expect(screen.getByTestId("actions")).not.toHaveStyle({
         transform: "translateX(0px)",
       });
-      expect(getByTestId("ratings")).toHaveStyle({
+      expect(screen.getByTestId("ratings")).toHaveStyle({
         transform: "translateX(0px)",
       });
     });
 
-    fireEvent.mouseOut(getByTestId("rating"));
+    fireEvent.mouseOut(screen.getByTestId("rating"));
 
     await waitFor(() => {
-      expect(getByTestId("actions")).toHaveStyle({
+      expect(screen.getByTestId("actions")).toHaveStyle({
         transform: "translateX(0px)",
       });
-      expect(getByTestId("ratings")).not.toHaveStyle({
+      expect(screen.getByTestId("ratings")).not.toHaveStyle({
         transform: "translateX(0px)",
       });
     });
@@ -173,33 +168,33 @@ describe("movie", () => {
   it("should toggle the actions and ratings when clicking the five star rating", async ({
     props,
   }) => {
-    const { getByTestId } = renderWithProviders(<Movie {...props} />);
+    renderWithProviders(<Movie {...props} />);
 
-    expect(getByTestId("actions")).toHaveStyle({
+    expect(screen.getByTestId("actions")).toHaveStyle({
       transform: "translateX(0px)",
     });
-    expect(getByTestId("ratings")).not.toHaveStyle({
+    expect(screen.getByTestId("ratings")).not.toHaveStyle({
       transform: "translateX(0px)",
     });
 
-    fireEvent.click(getByTestId("rating"));
+    fireEvent.click(screen.getByTestId("rating"));
 
     await waitFor(() => {
-      expect(getByTestId("actions")).not.toHaveStyle({
+      expect(screen.getByTestId("actions")).not.toHaveStyle({
         transform: "translateX(0px)",
       });
-      expect(getByTestId("ratings")).toHaveStyle({
+      expect(screen.getByTestId("ratings")).toHaveStyle({
         transform: "translateX(0px)",
       });
     });
 
-    fireEvent.click(getByTestId("rating"));
+    fireEvent.click(screen.getByTestId("rating"));
 
     await waitFor(() => {
-      expect(getByTestId("actions")).toHaveStyle({
+      expect(screen.getByTestId("actions")).toHaveStyle({
         transform: "translateX(0px)",
       });
-      expect(getByTestId("ratings")).not.toHaveStyle({
+      expect(screen.getByTestId("ratings")).not.toHaveStyle({
         transform: "translateX(0px)",
       });
     });
@@ -208,49 +203,41 @@ describe("movie", () => {
   it("should send the edit action and close the zoomed view", async ({
     props,
   }) => {
-    const { getByLabelText, getByTestId } = renderWithProviders(
-      <Movie {...props} />
-    );
-    fireEvent.click(getByLabelText("Edit"));
+    renderWithProviders(<Movie {...props} />);
+    fireEvent.click(screen.getByLabelText("Edit"));
     expect(props.onEditMovie).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 })
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
     );
   });
 
   it("should send the mark watched action and close the zoomed view", async ({
     props,
   }) => {
-    const { getByLabelText, getByTestId } = renderWithProviders(
-      <Movie {...props} />
-    );
-    fireEvent.click(getByLabelText("Mark as Watched"));
+    renderWithProviders(<Movie {...props} />);
+    fireEvent.click(screen.getByLabelText("Mark as Watched"));
     expect(props.onMarkWatched).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 })
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
     );
   });
 
   it("should send the delete action and close the zoomed view", async ({
     props,
   }) => {
-    const { getByLabelText, getByTestId } = renderWithProviders(
-      <Movie {...props} />
-    );
-    fireEvent.click(getByLabelText("Delete"));
+    renderWithProviders(<Movie {...props} />);
+    fireEvent.click(screen.getByLabelText("Delete"));
     expect(props.onDeleteMovie).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 })
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
     );
   });
 
   it("should send the edit action with locked:true and close the zoomed view", async ({
     props,
   }) => {
-    const { getByLabelText, getByTestId } = renderWithProviders(
-      <Movie {...props} />
-    );
-    fireEvent.click(getByLabelText("Lock"));
+    renderWithProviders(<Movie {...props} />);
+    fireEvent.click(screen.getByLabelText("Lock"));
     expect(props.onEditMovie).toHaveBeenCalledWith(
       {
         ...props.movie,
@@ -259,17 +246,17 @@ describe("movie", () => {
       false
     );
     await waitFor(() =>
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 })
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
     );
   });
 
   it("should send the edit action with locked:false and close the zoomed view", async ({
     props,
   }) => {
-    const { getByLabelText, getByTestId } = renderWithProviders(
+    renderWithProviders(
       <Movie {...props} movie={{ ...props.movie, locked: true }} />
     );
-    fireEvent.click(getByLabelText("Unlock"));
+    fireEvent.click(screen.getByLabelText("Unlock"));
     expect(props.onEditMovie).toHaveBeenCalledWith(
       {
         ...props.movie,
@@ -278,7 +265,7 @@ describe("movie", () => {
       false
     );
     await waitFor(() =>
-      expect(getByTestId("positioner")).toHaveStyle({ opacity: 0 })
+      expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
     );
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.jsx
@@ -20,10 +20,8 @@ vi.mock("../../../../../../../../hooks/use-sort-direction", () => ({
 }));
 
 describe("sorted-added", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movies: [
         {
           id: 0,
@@ -72,7 +70,7 @@ describe("sorted-added", () => {
     };
   });
 
-  it("should render correctly when the order is ASC", () => {
+  it("should render correctly when the order is ASC", ({ props }) => {
     const { getByTestId } = render(<SortedAdded {...props} />);
 
     expect(
@@ -116,7 +114,7 @@ describe("sorted-added", () => {
     expect(section4[1]).toHaveAttribute("aria-label", "Movie 1a");
   });
 
-  it("should render correctly when the order is DESC", () => {
+  it("should render correctly when the order is DESC", ({ props }) => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
@@ -163,7 +161,7 @@ describe("sorted-added", () => {
     expect(section4[1]).toHaveAttribute("aria-label", "Movie 4b");
   });
 
-  it("should call the edit handler", () => {
+  it("should call the edit handler", ({ props }) => {
     const { getByText } = render(<SortedAdded {...props} />);
     fireEvent.click(
       within(getByText("Movie 1a")).getByRole("button", { name: "Edit" })
@@ -173,7 +171,7 @@ describe("sorted-added", () => {
     );
   });
 
-  it("should call the mark watched handler", () => {
+  it("should call the mark watched handler", ({ props }) => {
     const { getByText } = render(<SortedAdded {...props} />);
     fireEvent.click(
       within(getByText("Movie 1a")).getByRole("button", {
@@ -185,7 +183,7 @@ describe("sorted-added", () => {
     );
   });
 
-  it("should call the delete handler", () => {
+  it("should call the delete handler", ({ props }) => {
     const { getByText } = render(<SortedAdded {...props} />);
     fireEvent.click(
       within(getByText("Movie 1a")).getByRole("button", { name: "Delete" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within, screen } from "@testing-library/react";
+import { render, within, screen } from "@testing-library/react";
 import SortedAdded from "./sorted-added";
 import { vi } from "vitest";
 import { formatISO, subDays, subMonths } from "date-fns";
@@ -161,9 +161,9 @@ describe("sorted-added", () => {
     expect(section4[1]).toHaveAttribute("aria-label", "Movie 4b");
   });
 
-  it("should call the edit handler", ({ props }) => {
+  it("should call the edit handler", async ({ props, user }) => {
     render(<SortedAdded {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Edit",
       })
@@ -173,9 +173,9 @@ describe("sorted-added", () => {
     );
   });
 
-  it("should call the mark watched handler", ({ props }) => {
+  it("should call the mark watched handler", async ({ props, user }) => {
     render(<SortedAdded {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Mark Watched",
       })
@@ -185,9 +185,9 @@ describe("sorted-added", () => {
     );
   });
 
-  it("should call the delete handler", ({ props }) => {
+  it("should call the delete handler", async ({ props, user }) => {
     render(<SortedAdded {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Delete",
       })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from "@testing-library/react";
+import { fireEvent, render, within, screen } from "@testing-library/react";
 import SortedAdded from "./sorted-added";
 import { vi } from "vitest";
 import { formatISO, subDays, subMonths } from "date-fns";
@@ -71,44 +71,44 @@ describe("sorted-added", () => {
   });
 
   it("should render correctly when the order is ASC", ({ props }) => {
-    const { getByTestId } = render(<SortedAdded {...props} />);
+    render(<SortedAdded {...props} />);
 
     expect(
-      within(getByTestId("addedOn").childNodes[0]).getByText(/Long/)
+      within(screen.getByTestId("addedOn").childNodes[0]).getByText(/Long/)
     ).toBeInTheDocument();
-    const section1 = within(getByTestId("addedOn").childNodes[0]).getAllByText(
-      /Movie 4/
-    );
+    const section1 = within(
+      screen.getByTestId("addedOn").childNodes[0]
+    ).getAllByText(/Movie 4/);
     expect(section1).toHaveLength(2);
     expect(section1[0]).toHaveAttribute("aria-label", "Movie 4b");
     expect(section1[1]).toHaveAttribute("aria-label", "Movie 4a");
 
     expect(
-      within(getByTestId("addedOn").childNodes[1]).getByText(/Year/)
+      within(screen.getByTestId("addedOn").childNodes[1]).getByText(/Year/)
     ).toBeInTheDocument();
-    const section2 = within(getByTestId("addedOn").childNodes[1]).getAllByText(
-      /Movie 3/
-    );
+    const section2 = within(
+      screen.getByTestId("addedOn").childNodes[1]
+    ).getAllByText(/Movie 3/);
     expect(section2).toHaveLength(2);
     expect(section2[0]).toHaveAttribute("aria-label", "Movie 3b");
     expect(section2[1]).toHaveAttribute("aria-label", "Movie 3a");
 
     expect(
-      within(getByTestId("addedOn").childNodes[2]).getByText(/While/)
+      within(screen.getByTestId("addedOn").childNodes[2]).getByText(/While/)
     ).toBeInTheDocument();
-    const section3 = within(getByTestId("addedOn").childNodes[2]).getAllByText(
-      /Movie 2/
-    );
+    const section3 = within(
+      screen.getByTestId("addedOn").childNodes[2]
+    ).getAllByText(/Movie 2/);
     expect(section3).toHaveLength(2);
     expect(section3[0]).toHaveAttribute("aria-label", "Movie 2b");
     expect(section3[1]).toHaveAttribute("aria-label", "Movie 2a");
 
     expect(
-      within(getByTestId("addedOn").childNodes[3]).getByText(/Recently/)
+      within(screen.getByTestId("addedOn").childNodes[3]).getByText(/Recently/)
     ).toBeInTheDocument();
-    const section4 = within(getByTestId("addedOn").childNodes[3]).getAllByText(
-      /Movie 1/
-    );
+    const section4 = within(
+      screen.getByTestId("addedOn").childNodes[3]
+    ).getAllByText(/Movie 1/);
     expect(section4).toHaveLength(2);
     expect(section4[0]).toHaveAttribute("aria-label", "Movie 1b");
     expect(section4[1]).toHaveAttribute("aria-label", "Movie 1a");
@@ -118,53 +118,55 @@ describe("sorted-added", () => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
-    const { getByTestId } = render(<SortedAdded {...props} />);
+    render(<SortedAdded {...props} />);
 
     expect(
-      within(getByTestId("addedOn").childNodes[0]).getByText(/Recently/)
+      within(screen.getByTestId("addedOn").childNodes[0]).getByText(/Recently/)
     ).toBeInTheDocument();
-    const section1 = within(getByTestId("addedOn").childNodes[0]).getAllByText(
-      /Movie 1/
-    );
+    const section1 = within(
+      screen.getByTestId("addedOn").childNodes[0]
+    ).getAllByText(/Movie 1/);
     expect(section1).toHaveLength(2);
     expect(section1[0]).toHaveAttribute("aria-label", "Movie 1a");
     expect(section1[1]).toHaveAttribute("aria-label", "Movie 1b");
 
     expect(
-      within(getByTestId("addedOn").childNodes[1]).getByText(/While/)
+      within(screen.getByTestId("addedOn").childNodes[1]).getByText(/While/)
     ).toBeInTheDocument();
-    const section2 = within(getByTestId("addedOn").childNodes[1]).getAllByText(
-      /Movie 2/
-    );
+    const section2 = within(
+      screen.getByTestId("addedOn").childNodes[1]
+    ).getAllByText(/Movie 2/);
     expect(section2).toHaveLength(2);
     expect(section2[0]).toHaveAttribute("aria-label", "Movie 2a");
     expect(section2[1]).toHaveAttribute("aria-label", "Movie 2b");
 
     expect(
-      within(getByTestId("addedOn").childNodes[2]).getByText(/Year/)
+      within(screen.getByTestId("addedOn").childNodes[2]).getByText(/Year/)
     ).toBeInTheDocument();
-    const section3 = within(getByTestId("addedOn").childNodes[2]).getAllByText(
-      /Movie 3/
-    );
+    const section3 = within(
+      screen.getByTestId("addedOn").childNodes[2]
+    ).getAllByText(/Movie 3/);
     expect(section3).toHaveLength(2);
     expect(section3[0]).toHaveAttribute("aria-label", "Movie 3a");
     expect(section3[1]).toHaveAttribute("aria-label", "Movie 3b");
 
     expect(
-      within(getByTestId("addedOn").childNodes[3]).getByText(/Long/)
+      within(screen.getByTestId("addedOn").childNodes[3]).getByText(/Long/)
     ).toBeInTheDocument();
-    const section4 = within(getByTestId("addedOn").childNodes[3]).getAllByText(
-      /Movie 4/
-    );
+    const section4 = within(
+      screen.getByTestId("addedOn").childNodes[3]
+    ).getAllByText(/Movie 4/);
     expect(section4).toHaveLength(2);
     expect(section4[0]).toHaveAttribute("aria-label", "Movie 4a");
     expect(section4[1]).toHaveAttribute("aria-label", "Movie 4b");
   });
 
   it("should call the edit handler", ({ props }) => {
-    const { getByText } = render(<SortedAdded {...props} />);
+    render(<SortedAdded {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1a")).getByRole("button", { name: "Edit" })
+      within(screen.getByText("Movie 1a")).getByRole("button", {
+        name: "Edit",
+      })
     );
     expect(props.onEditMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1a" })
@@ -172,9 +174,9 @@ describe("sorted-added", () => {
   });
 
   it("should call the mark watched handler", ({ props }) => {
-    const { getByText } = render(<SortedAdded {...props} />);
+    render(<SortedAdded {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1a")).getByRole("button", {
+      within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Mark Watched",
       })
     );
@@ -184,9 +186,11 @@ describe("sorted-added", () => {
   });
 
   it("should call the delete handler", ({ props }) => {
-    const { getByText } = render(<SortedAdded {...props} />);
+    render(<SortedAdded {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1a")).getByRole("button", { name: "Delete" })
+      within(screen.getByText("Movie 1a")).getByRole("button", {
+        name: "Delete",
+      })
     );
     expect(props.onDeleteMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1a" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within, screen } from "@testing-library/react";
+import { render, within, screen } from "@testing-library/react";
 import SortedGenre from "./sorted-genre";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -116,9 +116,9 @@ describe("sorted-genre", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call the edit handler", ({ props }) => {
+  it("should call the edit handler", async ({ props, user }) => {
     render(<SortedGenre {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Edit",
       })
@@ -128,9 +128,9 @@ describe("sorted-genre", () => {
     );
   });
 
-  it("should call the mark watched handler", ({ props }) => {
+  it("should call the mark watched handler", async ({ props, user }) => {
     render(<SortedGenre {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Mark Watched",
       })
@@ -140,9 +140,9 @@ describe("sorted-genre", () => {
     );
   });
 
-  it("should call the delete handler", ({ props }) => {
+  it("should call the delete handler", async ({ props, user }) => {
     render(<SortedGenre {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Delete",
       })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from "@testing-library/react";
+import { fireEvent, render, within, screen } from "@testing-library/react";
 import SortedGenre from "./sorted-genre";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -50,34 +50,34 @@ describe("sorted-genre", () => {
   });
 
   it("should render correctly when the order is ASC", ({ props }) => {
-    const { getByTestId } = render(<SortedGenre {...props} />);
+    render(<SortedGenre {...props} />);
 
     expect(
-      within(getByTestId("genre").childNodes[0]).getByText(/Comedy/)
+      within(screen.getByTestId("genre").childNodes[0]).getByText(/Comedy/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("genre").childNodes[0]).getByText("Movie 1")
-    ).toBeInTheDocument();
-
-    expect(
-      within(getByTestId("genre").childNodes[1]).getByText(/Drama/)
-    ).toBeInTheDocument();
-    expect(
-      within(getByTestId("genre").childNodes[1]).getByText("Movie 2")
+      within(screen.getByTestId("genre").childNodes[0]).getByText("Movie 1")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("genre").childNodes[2]).getByText(/Action/)
+      within(screen.getByTestId("genre").childNodes[1]).getByText(/Drama/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("genre").childNodes[2]).getByText("Movie 3")
+      within(screen.getByTestId("genre").childNodes[1]).getByText("Movie 2")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("genre").childNodes[3]).getByText(/Sci-Fi/)
+      within(screen.getByTestId("genre").childNodes[2]).getByText(/Action/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("genre").childNodes[3]).getByText("Movie 4")
+      within(screen.getByTestId("genre").childNodes[2]).getByText("Movie 3")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("genre").childNodes[3]).getByText(/Sci-Fi/)
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("genre").childNodes[3]).getByText("Movie 4")
     ).toBeInTheDocument();
   });
 
@@ -85,41 +85,43 @@ describe("sorted-genre", () => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
-    const { getByTestId } = render(<SortedGenre {...props} />);
+    render(<SortedGenre {...props} />);
 
     expect(
-      within(getByTestId("genre").childNodes[0]).getByText(/Sci-Fi/)
+      within(screen.getByTestId("genre").childNodes[0]).getByText(/Sci-Fi/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("genre").childNodes[0]).getByText("Movie 4")
-    ).toBeInTheDocument();
-
-    expect(
-      within(getByTestId("genre").childNodes[1]).getByText(/Action/)
-    ).toBeInTheDocument();
-    expect(
-      within(getByTestId("genre").childNodes[1]).getByText("Movie 3")
+      within(screen.getByTestId("genre").childNodes[0]).getByText("Movie 4")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("genre").childNodes[2]).getByText(/Drama/)
+      within(screen.getByTestId("genre").childNodes[1]).getByText(/Action/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("genre").childNodes[2]).getByText("Movie 2")
+      within(screen.getByTestId("genre").childNodes[1]).getByText("Movie 3")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("genre").childNodes[3]).getByText(/Comedy/)
+      within(screen.getByTestId("genre").childNodes[2]).getByText(/Drama/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("genre").childNodes[3]).getByText("Movie 1")
+      within(screen.getByTestId("genre").childNodes[2]).getByText("Movie 2")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("genre").childNodes[3]).getByText(/Comedy/)
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("genre").childNodes[3]).getByText("Movie 1")
     ).toBeInTheDocument();
   });
 
   it("should call the edit handler", ({ props }) => {
-    const { getByText } = render(<SortedGenre {...props} />);
+    render(<SortedGenre {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Edit" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Edit",
+      })
     );
     expect(props.onEditMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })
@@ -127,9 +129,11 @@ describe("sorted-genre", () => {
   });
 
   it("should call the mark watched handler", ({ props }) => {
-    const { getByText } = render(<SortedGenre {...props} />);
+    render(<SortedGenre {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Mark Watched" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Mark Watched",
+      })
     );
     expect(props.onMarkWatched).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })
@@ -137,9 +141,11 @@ describe("sorted-genre", () => {
   });
 
   it("should call the delete handler", ({ props }) => {
-    const { getByText } = render(<SortedGenre {...props} />);
+    render(<SortedGenre {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Delete" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Delete",
+      })
     );
     expect(props.onDeleteMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.jsx
@@ -19,10 +19,8 @@ vi.mock("../../../../../../../../hooks/use-sort-direction", () => ({
 }));
 
 describe("sorted-genre", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movies: [
         {
           id: 0,
@@ -51,7 +49,7 @@ describe("sorted-genre", () => {
     };
   });
 
-  it("should render correctly when the order is ASC", () => {
+  it("should render correctly when the order is ASC", ({ props }) => {
     const { getByTestId } = render(<SortedGenre {...props} />);
 
     expect(
@@ -83,7 +81,7 @@ describe("sorted-genre", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render correctly when the order is DESC", () => {
+  it("should render correctly when the order is DESC", ({ props }) => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
@@ -118,7 +116,7 @@ describe("sorted-genre", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call the edit handler", () => {
+  it("should call the edit handler", ({ props }) => {
     const { getByText } = render(<SortedGenre {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Edit" })
@@ -128,7 +126,7 @@ describe("sorted-genre", () => {
     );
   });
 
-  it("should call the mark watched handler", () => {
+  it("should call the mark watched handler", ({ props }) => {
     const { getByText } = render(<SortedGenre {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Mark Watched" })
@@ -138,7 +136,7 @@ describe("sorted-genre", () => {
     );
   });
 
-  it("should call the delete handler", () => {
+  it("should call the delete handler", ({ props }) => {
     const { getByText } = render(<SortedGenre {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Delete" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from "@testing-library/react";
+import { fireEvent, render, within, screen } from "@testing-library/react";
 import SortedRating from "./sorted-rating";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -85,7 +85,7 @@ describe("sorted-rating", () => {
   });
 
   it("should only render sections with movies", ({ props }) => {
-    const { getAllByLabelText } = render(
+    render(
       <SortedRating
         {...props}
         movies={props.movies.filter(
@@ -96,7 +96,7 @@ describe("sorted-rating", () => {
     );
 
     // Sorted Sections
-    const sections = getAllByLabelText(/Star/);
+    const sections = screen.getAllByLabelText(/Star/);
     expect(sections).toHaveLength(3);
     expect(sections[0]).toHaveAttribute("aria-label", "1 Star");
     expect(sections[1]).toHaveAttribute("aria-label", "2 Star");
@@ -104,12 +104,10 @@ describe("sorted-rating", () => {
   });
 
   it("should render correctly when the order is ASC", ({ props }) => {
-    const { getByLabelText, getAllByLabelText } = render(
-      <SortedRating {...props} />
-    );
+    render(<SortedRating {...props} />);
 
     // Sorted Sections
-    const sections = getAllByLabelText(/Star/);
+    const sections = screen.getAllByLabelText(/Star/);
     expect(sections[0]).toHaveAttribute("aria-label", "0 Star");
     expect(sections[1]).toHaveAttribute("aria-label", "1 Star");
     expect(sections[2]).toHaveAttribute("aria-label", "2 Star");
@@ -119,14 +117,14 @@ describe("sorted-rating", () => {
 
     // 0 Star Section
     const section0 = within(
-      getByLabelText("0 Star").childNodes[1]
+      screen.getByLabelText("0 Star").childNodes[1]
     ).getAllByText(/Movie 0/);
     expect(section0).toHaveLength(1);
     expect(section0[0]).toHaveAttribute("aria-label", "Movie 0");
 
     // 1 Star Section
     const section1 = within(
-      getByLabelText("1 Star").childNodes[1]
+      screen.getByLabelText("1 Star").childNodes[1]
     ).getAllByText(/Movie 1/);
     expect(section1).toHaveLength(2);
     expect(section1[0]).toHaveAttribute("aria-label", "Movie 1a");
@@ -134,7 +132,7 @@ describe("sorted-rating", () => {
 
     // 2 Star Section
     const section2 = within(
-      getByLabelText("2 Star").childNodes[1]
+      screen.getByLabelText("2 Star").childNodes[1]
     ).getAllByText(/Movie 2/);
     expect(section2).toHaveLength(2);
     expect(section2[0]).toHaveAttribute("aria-label", "Movie 2a");
@@ -142,7 +140,7 @@ describe("sorted-rating", () => {
 
     // 3 Star Section
     const section3 = within(
-      getByLabelText("3 Star").childNodes[1]
+      screen.getByLabelText("3 Star").childNodes[1]
     ).getAllByText(/Movie 3/);
     expect(section3).toHaveLength(2);
     expect(section3[0]).toHaveAttribute("aria-label", "Movie 3a");
@@ -150,7 +148,7 @@ describe("sorted-rating", () => {
 
     // 4 Star Section
     const section4 = within(
-      getByLabelText("4 Star").childNodes[1]
+      screen.getByLabelText("4 Star").childNodes[1]
     ).getAllByText(/Movie 4/);
     expect(section4).toHaveLength(2);
     expect(section4[0]).toHaveAttribute("aria-label", "Movie 4a");
@@ -158,7 +156,7 @@ describe("sorted-rating", () => {
 
     // 5 Star Section
     const section5 = within(
-      getByLabelText("5 Star").childNodes[1]
+      screen.getByLabelText("5 Star").childNodes[1]
     ).getAllByText(/Movie 5/);
     expect(section5).toHaveLength(2);
     expect(section5[0]).toHaveAttribute("aria-label", "Movie 5a");
@@ -169,12 +167,10 @@ describe("sorted-rating", () => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
-    const { getByLabelText, getAllByLabelText } = render(
-      <SortedRating {...props} />
-    );
+    render(<SortedRating {...props} />);
 
     // Sorted Sections
-    const sections = getAllByLabelText(/Star/);
+    const sections = screen.getAllByLabelText(/Star/);
     expect(sections[0]).toHaveAttribute("aria-label", "5 Star");
     expect(sections[1]).toHaveAttribute("aria-label", "4 Star");
     expect(sections[2]).toHaveAttribute("aria-label", "3 Star");
@@ -184,14 +180,14 @@ describe("sorted-rating", () => {
 
     // 0 Star Section
     const section0 = within(
-      getByLabelText("0 Star").childNodes[1]
+      screen.getByLabelText("0 Star").childNodes[1]
     ).getAllByText(/Movie 0/);
     expect(section0).toHaveLength(1);
     expect(section0[0]).toHaveAttribute("aria-label", "Movie 0");
 
     // 1 Star Section
     const section1 = within(
-      getByLabelText("1 Star").childNodes[1]
+      screen.getByLabelText("1 Star").childNodes[1]
     ).getAllByText(/Movie 1/);
     expect(section1).toHaveLength(2);
     expect(section1[0]).toHaveAttribute("aria-label", "Movie 1a");
@@ -199,7 +195,7 @@ describe("sorted-rating", () => {
 
     // 2 Star Section
     const section2 = within(
-      getByLabelText("2 Star").childNodes[1]
+      screen.getByLabelText("2 Star").childNodes[1]
     ).getAllByText(/Movie 2/);
     expect(section2).toHaveLength(2);
     expect(section2[0]).toHaveAttribute("aria-label", "Movie 2a");
@@ -207,7 +203,7 @@ describe("sorted-rating", () => {
 
     // 3 Star Section
     const section3 = within(
-      getByLabelText("3 Star").childNodes[1]
+      screen.getByLabelText("3 Star").childNodes[1]
     ).getAllByText(/Movie 3/);
     expect(section3).toHaveLength(2);
     expect(section3[0]).toHaveAttribute("aria-label", "Movie 3a");
@@ -215,7 +211,7 @@ describe("sorted-rating", () => {
 
     // 4 Star Section
     const section4 = within(
-      getByLabelText("4 Star").childNodes[1]
+      screen.getByLabelText("4 Star").childNodes[1]
     ).getAllByText(/Movie 4/);
     expect(section4).toHaveLength(2);
     expect(section4[0]).toHaveAttribute("aria-label", "Movie 4a");
@@ -223,7 +219,7 @@ describe("sorted-rating", () => {
 
     // 5 Star Section
     const section5 = within(
-      getByLabelText("5 Star").childNodes[1]
+      screen.getByLabelText("5 Star").childNodes[1]
     ).getAllByText(/Movie 5/);
     expect(section5).toHaveLength(2);
     expect(section5[0]).toHaveAttribute("aria-label", "Movie 5a");
@@ -231,9 +227,11 @@ describe("sorted-rating", () => {
   });
 
   it("should call the edit handler", ({ props }) => {
-    const { getByText } = render(<SortedRating {...props} />);
+    render(<SortedRating {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1a")).getByRole("button", { name: "Edit" })
+      within(screen.getByText("Movie 1a")).getByRole("button", {
+        name: "Edit",
+      })
     );
     expect(props.onEditMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1a" })
@@ -241,9 +239,9 @@ describe("sorted-rating", () => {
   });
 
   it("should call the mark watched handler", ({ props }) => {
-    const { getByText } = render(<SortedRating {...props} />);
+    render(<SortedRating {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1a")).getByRole("button", {
+      within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Mark Watched",
       })
     );
@@ -253,9 +251,11 @@ describe("sorted-rating", () => {
   });
 
   it("should call the delete handler", ({ props }) => {
-    const { getByText } = render(<SortedRating {...props} />);
+    render(<SortedRating {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1a")).getByRole("button", { name: "Delete" })
+      within(screen.getByText("Movie 1a")).getByRole("button", {
+        name: "Delete",
+      })
     );
     expect(props.onDeleteMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1a" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within, screen } from "@testing-library/react";
+import { render, within, screen } from "@testing-library/react";
 import SortedRating from "./sorted-rating";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -226,9 +226,9 @@ describe("sorted-rating", () => {
     expect(section5[1]).toHaveAttribute("aria-label", "Movie 5b");
   });
 
-  it("should call the edit handler", ({ props }) => {
+  it("should call the edit handler", async ({ props, user }) => {
     render(<SortedRating {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Edit",
       })
@@ -238,9 +238,9 @@ describe("sorted-rating", () => {
     );
   });
 
-  it("should call the mark watched handler", ({ props }) => {
+  it("should call the mark watched handler", async ({ props, user }) => {
     render(<SortedRating {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Mark Watched",
       })
@@ -250,9 +250,9 @@ describe("sorted-rating", () => {
     );
   });
 
-  it("should call the delete handler", ({ props }) => {
+  it("should call the delete handler", async ({ props, user }) => {
     render(<SortedRating {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1a")).getByRole("button", {
         name: "Delete",
       })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.jsx
@@ -19,10 +19,8 @@ vi.mock("../../../../../../../../hooks/use-sort-direction", () => ({
 }));
 
 describe("sorted-rating", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movies: [
         {
           id: 0,
@@ -86,7 +84,7 @@ describe("sorted-rating", () => {
     };
   });
 
-  it("should only render sections with movies", () => {
+  it("should only render sections with movies", ({ props }) => {
     const { getAllByLabelText } = render(
       <SortedRating
         {...props}
@@ -105,7 +103,7 @@ describe("sorted-rating", () => {
     expect(sections[2]).toHaveAttribute("aria-label", "4 Star");
   });
 
-  it("should render correctly when the order is ASC", () => {
+  it("should render correctly when the order is ASC", ({ props }) => {
     const { getByLabelText, getAllByLabelText } = render(
       <SortedRating {...props} />
     );
@@ -167,7 +165,7 @@ describe("sorted-rating", () => {
     expect(section5[1]).toHaveAttribute("aria-label", "Movie 5b");
   });
 
-  it("should render correctly when the order is DESC", () => {
+  it("should render correctly when the order is DESC", ({ props }) => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
@@ -232,7 +230,7 @@ describe("sorted-rating", () => {
     expect(section5[1]).toHaveAttribute("aria-label", "Movie 5b");
   });
 
-  it("should call the edit handler", () => {
+  it("should call the edit handler", ({ props }) => {
     const { getByText } = render(<SortedRating {...props} />);
     fireEvent.click(
       within(getByText("Movie 1a")).getByRole("button", { name: "Edit" })
@@ -242,7 +240,7 @@ describe("sorted-rating", () => {
     );
   });
 
-  it("should call the mark watched handler", () => {
+  it("should call the mark watched handler", ({ props }) => {
     const { getByText } = render(<SortedRating {...props} />);
     fireEvent.click(
       within(getByText("Movie 1a")).getByRole("button", {
@@ -254,7 +252,7 @@ describe("sorted-rating", () => {
     );
   });
 
-  it("should call the delete handler", () => {
+  it("should call the delete handler", ({ props }) => {
     const { getByText } = render(<SortedRating {...props} />);
     fireEvent.click(
       within(getByText("Movie 1a")).getByRole("button", { name: "Delete" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from "@testing-library/react";
+import { fireEvent, render, within, screen } from "@testing-library/react";
 import SortedRuntime from "./sorted-runtime";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -50,34 +50,36 @@ describe("sorted-runtime", () => {
   });
 
   it("should render correctly when the order is ASC", ({ props }) => {
-    const { getByTestId } = render(<SortedRuntime {...props} />);
+    render(<SortedRuntime {...props} />);
 
     expect(
-      within(getByTestId("runtime").childNodes[0]).getByText(/Short/)
+      within(screen.getByTestId("runtime").childNodes[0]).getByText(/Short/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("runtime").childNodes[0]).getByText("Movie 1")
-    ).toBeInTheDocument();
-
-    expect(
-      within(getByTestId("runtime").childNodes[1]).getByText(/Regular/)
-    ).toBeInTheDocument();
-    expect(
-      within(getByTestId("runtime").childNodes[1]).getByText("Movie 2")
+      within(screen.getByTestId("runtime").childNodes[0]).getByText("Movie 1")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("runtime").childNodes[2]).getByText(/Long/)
+      within(screen.getByTestId("runtime").childNodes[1]).getByText(/Regular/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("runtime").childNodes[2]).getByText("Movie 3")
+      within(screen.getByTestId("runtime").childNodes[1]).getByText("Movie 2")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("runtime").childNodes[3]).getByText(/No Runtime/)
+      within(screen.getByTestId("runtime").childNodes[2]).getByText(/Long/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("runtime").childNodes[3]).getByText("Movie 4")
+      within(screen.getByTestId("runtime").childNodes[2]).getByText("Movie 3")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("runtime").childNodes[3]).getByText(
+        /No Runtime/
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("runtime").childNodes[3]).getByText("Movie 4")
     ).toBeInTheDocument();
   });
 
@@ -85,41 +87,45 @@ describe("sorted-runtime", () => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
-    const { getByTestId } = render(<SortedRuntime {...props} />);
+    render(<SortedRuntime {...props} />);
 
     expect(
-      within(getByTestId("runtime").childNodes[0]).getByText(/Long/)
+      within(screen.getByTestId("runtime").childNodes[0]).getByText(/Long/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("runtime").childNodes[0]).getByText("Movie 3")
-    ).toBeInTheDocument();
-
-    expect(
-      within(getByTestId("runtime").childNodes[1]).getByText(/Regular/)
-    ).toBeInTheDocument();
-    expect(
-      within(getByTestId("runtime").childNodes[1]).getByText("Movie 2")
+      within(screen.getByTestId("runtime").childNodes[0]).getByText("Movie 3")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("runtime").childNodes[2]).getByText(/Short/)
+      within(screen.getByTestId("runtime").childNodes[1]).getByText(/Regular/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("runtime").childNodes[2]).getByText("Movie 1")
+      within(screen.getByTestId("runtime").childNodes[1]).getByText("Movie 2")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("runtime").childNodes[3]).getByText(/No Runtime/)
+      within(screen.getByTestId("runtime").childNodes[2]).getByText(/Short/)
     ).toBeInTheDocument();
     expect(
-      within(getByTestId("runtime").childNodes[3]).getByText("Movie 4")
+      within(screen.getByTestId("runtime").childNodes[2]).getByText("Movie 1")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("runtime").childNodes[3]).getByText(
+        /No Runtime/
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("runtime").childNodes[3]).getByText("Movie 4")
     ).toBeInTheDocument();
   });
 
   it("should call the edit handler", ({ props }) => {
-    const { getByText } = render(<SortedRuntime {...props} />);
+    render(<SortedRuntime {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Edit" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Edit",
+      })
     );
     expect(props.onEditMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })
@@ -127,9 +133,11 @@ describe("sorted-runtime", () => {
   });
 
   it("should call the mark watched handler", ({ props }) => {
-    const { getByText } = render(<SortedRuntime {...props} />);
+    render(<SortedRuntime {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Mark Watched" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Mark Watched",
+      })
     );
     expect(props.onMarkWatched).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })
@@ -137,9 +145,11 @@ describe("sorted-runtime", () => {
   });
 
   it("should call the delete handler", ({ props }) => {
-    const { getByText } = render(<SortedRuntime {...props} />);
+    render(<SortedRuntime {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Delete" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Delete",
+      })
     );
     expect(props.onDeleteMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within, screen } from "@testing-library/react";
+import { render, within, screen } from "@testing-library/react";
 import SortedRuntime from "./sorted-runtime";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -120,9 +120,9 @@ describe("sorted-runtime", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call the edit handler", ({ props }) => {
+  it("should call the edit handler", async ({ props, user }) => {
     render(<SortedRuntime {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Edit",
       })
@@ -132,9 +132,9 @@ describe("sorted-runtime", () => {
     );
   });
 
-  it("should call the mark watched handler", ({ props }) => {
+  it("should call the mark watched handler", async ({ props, user }) => {
     render(<SortedRuntime {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Mark Watched",
       })
@@ -144,9 +144,9 @@ describe("sorted-runtime", () => {
     );
   });
 
-  it("should call the delete handler", ({ props }) => {
+  it("should call the delete handler", async ({ props, user }) => {
     render(<SortedRuntime {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Delete",
       })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.jsx
@@ -19,10 +19,8 @@ vi.mock("../../../../../../../../hooks/use-sort-direction", () => ({
 }));
 
 describe("sorted-runtime", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movies: [
         {
           id: 0,
@@ -51,7 +49,7 @@ describe("sorted-runtime", () => {
     };
   });
 
-  it("should render correctly when the order is ASC", () => {
+  it("should render correctly when the order is ASC", ({ props }) => {
     const { getByTestId } = render(<SortedRuntime {...props} />);
 
     expect(
@@ -83,7 +81,7 @@ describe("sorted-runtime", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render correctly when the order is DESC", () => {
+  it("should render correctly when the order is DESC", ({ props }) => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
@@ -118,7 +116,7 @@ describe("sorted-runtime", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call the edit handler", () => {
+  it("should call the edit handler", ({ props }) => {
     const { getByText } = render(<SortedRuntime {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Edit" })
@@ -128,7 +126,7 @@ describe("sorted-runtime", () => {
     );
   });
 
-  it("should call the mark watched handler", () => {
+  it("should call the mark watched handler", ({ props }) => {
     const { getByText } = render(<SortedRuntime {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Mark Watched" })
@@ -138,7 +136,7 @@ describe("sorted-runtime", () => {
     );
   });
 
-  it("should call the delete handler", () => {
+  it("should call the delete handler", ({ props }) => {
     const { getByText } = render(<SortedRuntime {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Delete" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from "@testing-library/react";
+import { fireEvent, render, within, screen } from "@testing-library/react";
 import SortedTitle from "./sorted-title";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -46,9 +46,9 @@ describe("sorted-title", () => {
   });
 
   it("should render correctly when the order is ASC", ({ props }) => {
-    const { queryAllByText } = render(<SortedTitle {...props} />);
+    render(<SortedTitle {...props} />);
 
-    const movieNodes = queryAllByText(/Movie/);
+    const movieNodes = screen.queryAllByText(/Movie/);
 
     expect(movieNodes).toHaveLength(4);
     expect(within(movieNodes[0]).getByText("Movie 1")).toBeInTheDocument();
@@ -61,9 +61,9 @@ describe("sorted-title", () => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
-    const { queryAllByText } = render(<SortedTitle {...props} />);
+    render(<SortedTitle {...props} />);
 
-    const movieNodes = queryAllByText(/Movie/);
+    const movieNodes = screen.queryAllByText(/Movie/);
 
     expect(movieNodes).toHaveLength(4);
     expect(within(movieNodes[0]).getByText("Movie 4")).toBeInTheDocument();
@@ -73,9 +73,11 @@ describe("sorted-title", () => {
   });
 
   it("should call the edit handler", ({ props }) => {
-    const { getByText } = render(<SortedTitle {...props} />);
+    render(<SortedTitle {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Edit" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Edit",
+      })
     );
     expect(props.onEditMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })
@@ -83,9 +85,11 @@ describe("sorted-title", () => {
   });
 
   it("should call the mark watched handler", ({ props }) => {
-    const { getByText } = render(<SortedTitle {...props} />);
+    render(<SortedTitle {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Mark Watched" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Mark Watched",
+      })
     );
     expect(props.onMarkWatched).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })
@@ -93,9 +97,11 @@ describe("sorted-title", () => {
   });
 
   it("should call the delete handler", ({ props }) => {
-    const { getByText } = render(<SortedTitle {...props} />);
+    render(<SortedTitle {...props} />);
     fireEvent.click(
-      within(getByText("Movie 1")).getByRole("button", { name: "Delete" })
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Delete",
+      })
     );
     expect(props.onDeleteMovie).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Movie 1" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.jsx
@@ -19,10 +19,8 @@ vi.mock("../../../../../../../../hooks/use-sort-direction", () => ({
 }));
 
 describe("sorted-title", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movies: [
         {
           id: 0,
@@ -47,7 +45,7 @@ describe("sorted-title", () => {
     };
   });
 
-  it("should render correctly when the order is ASC", () => {
+  it("should render correctly when the order is ASC", ({ props }) => {
     const { queryAllByText } = render(<SortedTitle {...props} />);
 
     const movieNodes = queryAllByText(/Movie/);
@@ -59,7 +57,7 @@ describe("sorted-title", () => {
     expect(within(movieNodes[3]).getByText("Movie 4")).toBeInTheDocument();
   });
 
-  it("should render correctly when the order is DESC", () => {
+  it("should render correctly when the order is DESC", ({ props }) => {
     // eslint-disable-next-line no-import-assign
     useSortDirectionModule.useSortDirection = vi.fn().mockReturnValue("desc");
 
@@ -74,7 +72,7 @@ describe("sorted-title", () => {
     expect(within(movieNodes[3]).getByText("Movie 1")).toBeInTheDocument();
   });
 
-  it("should call the edit handler", () => {
+  it("should call the edit handler", ({ props }) => {
     const { getByText } = render(<SortedTitle {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Edit" })
@@ -84,7 +82,7 @@ describe("sorted-title", () => {
     );
   });
 
-  it("should call the mark watched handler", () => {
+  it("should call the mark watched handler", ({ props }) => {
     const { getByText } = render(<SortedTitle {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Mark Watched" })
@@ -94,7 +92,7 @@ describe("sorted-title", () => {
     );
   });
 
-  it("should call the delete handler", () => {
+  it("should call the delete handler", ({ props }) => {
     const { getByText } = render(<SortedTitle {...props} />);
     fireEvent.click(
       within(getByText("Movie 1")).getByRole("button", { name: "Delete" })

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within, screen } from "@testing-library/react";
+import { render, within, screen } from "@testing-library/react";
 import SortedTitle from "./sorted-title";
 import { vi } from "vitest";
 import * as useSortDirectionModule from "../../../../../../../../hooks/use-sort-direction";
@@ -72,9 +72,9 @@ describe("sorted-title", () => {
     expect(within(movieNodes[3]).getByText("Movie 1")).toBeInTheDocument();
   });
 
-  it("should call the edit handler", ({ props }) => {
+  it("should call the edit handler", async ({ props, user }) => {
     render(<SortedTitle {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Edit",
       })
@@ -84,9 +84,9 @@ describe("sorted-title", () => {
     );
   });
 
-  it("should call the mark watched handler", ({ props }) => {
+  it("should call the mark watched handler", async ({ props, user }) => {
     render(<SortedTitle {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Mark Watched",
       })
@@ -96,9 +96,9 @@ describe("sorted-title", () => {
     );
   });
 
-  it("should call the delete handler", ({ props }) => {
+  it("should call the delete handler", async ({ props, user }) => {
     render(<SortedTitle {...props} />);
-    fireEvent.click(
+    await user.click(
       within(screen.getByText("Movie 1")).getByRole("button", {
         name: "Delete",
       })

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import ListGrid from "./list-grid";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
@@ -80,15 +80,16 @@ describe("list-grid", () => {
 
   it("should render the delete confirmation and call onRemoveMovie when deleting a movie", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<ListGrid {...props} />, {
       route: "/addedOn/asc",
     });
 
-    fireEvent.click(screen.getByText("Movie 1"));
+    await user.click(screen.getByText("Movie 1"));
     expect(screen.getByText("'Movie 1' will be removed")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
     expect(props.onRemoveMovie).toHaveBeenCalledWith(props.movies[0]);
     expect(
       screen.queryByText("'Movie 1' will be removed")
@@ -97,13 +98,14 @@ describe("list-grid", () => {
 
   it("should render the delete confirmation and cancel correctly when deleting a movie", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<ListGrid {...props} />, { route: "/addedOn/asc" });
 
-    fireEvent.click(screen.getByText("Movie 1"));
+    await user.click(screen.getByText("Movie 1"));
     expect(screen.getByText("'Movie 1' will be removed")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(props.onRemoveMovie).not.toHaveBeenCalled();
     expect(
       screen.queryByText("'Movie 1' will be removed")

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
@@ -17,10 +17,8 @@ vi.mock("./components/movie/movie", () => ({
 
 // NOTE: Routes passed to render-with-providers within this file are relative to the sub-routes since I am only rendering the list-grid itself.
 describe("list-grid", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movies: [
         {
           id: 0,
@@ -31,35 +29,37 @@ describe("list-grid", () => {
     };
   });
 
-  it("should render the addedOn list", async () => {
+  it("should render the addedOn list", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/addedOn/asc",
     });
     expect(getByTestId("addedOn")).toBeInTheDocument();
   });
 
-  it("should render the title list", async () => {
+  it("should render the title list", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/title/asc",
     });
     expect(getByTestId("title")).toBeInTheDocument();
   });
 
-  it("should render the runtime list", async () => {
+  it("should render the runtime list", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/runtime/asc",
     });
     expect(getByTestId("runtime")).toBeInTheDocument();
   });
 
-  it("should render the genre list", async () => {
+  it("should render the genre list", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/genre/asc",
     });
     expect(getByTestId("genre")).toBeInTheDocument();
   });
 
-  it("should render the empty list when there are no movies", async () => {
+  it("should render the empty list when there are no movies", async ({
+    props,
+  }) => {
     const { getByRole } = renderWithProviders(
       <ListGrid {...props} movies={[]} />,
       { route: "/addedOn/asc" }
@@ -67,7 +67,7 @@ describe("list-grid", () => {
     expect(getByRole("button", { name: "Add a Movie" })).toBeInTheDocument();
   });
 
-  it("should render null when movies is undefined", async () => {
+  it("should render null when movies is undefined", async ({ props }) => {
     const { queryByRole, queryByText } = renderWithProviders(
       <ListGrid {...props} movies={undefined} />,
       { route: "/addedOn/asc" }
@@ -78,7 +78,9 @@ describe("list-grid", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should render the delete confirmation and call onRemoveMovie when deleting a movie", async () => {
+  it("should render the delete confirmation and call onRemoveMovie when deleting a movie", async ({
+    props,
+  }) => {
     const { getByText, getByRole, queryByText } = renderWithProviders(
       <ListGrid {...props} />,
       {
@@ -94,7 +96,9 @@ describe("list-grid", () => {
     expect(queryByText("'Movie 1' will be removed")).not.toBeInTheDocument();
   });
 
-  it("should render the delete confirmation and cancel correctly when deleting a movie", async () => {
+  it("should render the delete confirmation and cancel correctly when deleting a movie", async ({
+    props,
+  }) => {
     const { getByText, getByRole, queryByText } = renderWithProviders(
       <ListGrid {...props} />,
       { route: "/addedOn/asc" }

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
@@ -32,35 +32,35 @@ describe("list-grid", () => {
   });
 
   it("should render the addedOn list", async () => {
-    const { getByTestId } = await renderWithProviders(<ListGrid {...props} />, {
+    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/addedOn/asc",
     });
     expect(getByTestId("addedOn")).toBeInTheDocument();
   });
 
   it("should render the title list", async () => {
-    const { getByTestId } = await renderWithProviders(<ListGrid {...props} />, {
+    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/title/asc",
     });
     expect(getByTestId("title")).toBeInTheDocument();
   });
 
   it("should render the runtime list", async () => {
-    const { getByTestId } = await renderWithProviders(<ListGrid {...props} />, {
+    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/runtime/asc",
     });
     expect(getByTestId("runtime")).toBeInTheDocument();
   });
 
   it("should render the genre list", async () => {
-    const { getByTestId } = await renderWithProviders(<ListGrid {...props} />, {
+    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
       route: "/genre/asc",
     });
     expect(getByTestId("genre")).toBeInTheDocument();
   });
 
   it("should render the empty list when there are no movies", async () => {
-    const { getByRole } = await renderWithProviders(
+    const { getByRole } = renderWithProviders(
       <ListGrid {...props} movies={[]} />,
       { route: "/addedOn/asc" }
     );
@@ -68,7 +68,7 @@ describe("list-grid", () => {
   });
 
   it("should render null when movies is undefined", async () => {
-    const { queryByRole, queryByText } = await renderWithProviders(
+    const { queryByRole, queryByText } = renderWithProviders(
       <ListGrid {...props} movies={undefined} />,
       { route: "/addedOn/asc" }
     );
@@ -79,7 +79,7 @@ describe("list-grid", () => {
   });
 
   it("should render the delete confirmation and call onRemoveMovie when deleting a movie", async () => {
-    const { getByText, getByRole, queryByText } = await renderWithProviders(
+    const { getByText, getByRole, queryByText } = renderWithProviders(
       <ListGrid {...props} />,
       {
         route: "/addedOn/asc",
@@ -95,7 +95,7 @@ describe("list-grid", () => {
   });
 
   it("should render the delete confirmation and cancel correctly when deleting a movie", async () => {
-    const { getByText, getByRole, queryByText } = await renderWithProviders(
+    const { getByText, getByRole, queryByText } = renderWithProviders(
       <ListGrid {...props} />,
       { route: "/addedOn/asc" }
     );

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import ListGrid from "./list-grid";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
@@ -30,85 +30,83 @@ describe("list-grid", () => {
   });
 
   it("should render the addedOn list", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
+    renderWithProviders(<ListGrid {...props} />, {
       route: "/addedOn/asc",
     });
-    expect(getByTestId("addedOn")).toBeInTheDocument();
+    expect(screen.getByTestId("addedOn")).toBeInTheDocument();
   });
 
   it("should render the title list", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
+    renderWithProviders(<ListGrid {...props} />, {
       route: "/title/asc",
     });
-    expect(getByTestId("title")).toBeInTheDocument();
+    expect(screen.getByTestId("title")).toBeInTheDocument();
   });
 
   it("should render the runtime list", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
+    renderWithProviders(<ListGrid {...props} />, {
       route: "/runtime/asc",
     });
-    expect(getByTestId("runtime")).toBeInTheDocument();
+    expect(screen.getByTestId("runtime")).toBeInTheDocument();
   });
 
   it("should render the genre list", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<ListGrid {...props} />, {
+    renderWithProviders(<ListGrid {...props} />, {
       route: "/genre/asc",
     });
-    expect(getByTestId("genre")).toBeInTheDocument();
+    expect(screen.getByTestId("genre")).toBeInTheDocument();
   });
 
   it("should render the empty list when there are no movies", async ({
     props,
   }) => {
-    const { getByRole } = renderWithProviders(
-      <ListGrid {...props} movies={[]} />,
-      { route: "/addedOn/asc" }
-    );
-    expect(getByRole("button", { name: "Add a Movie" })).toBeInTheDocument();
+    renderWithProviders(<ListGrid {...props} movies={[]} />, {
+      route: "/addedOn/asc",
+    });
+    expect(
+      screen.getByRole("button", { name: "Add a Movie" })
+    ).toBeInTheDocument();
   });
 
   it("should render null when movies is undefined", async ({ props }) => {
-    const { queryByRole, queryByText } = renderWithProviders(
-      <ListGrid {...props} movies={undefined} />,
-      { route: "/addedOn/asc" }
-    );
-    expect(queryByText(/Movie/)).not.toBeInTheDocument();
+    renderWithProviders(<ListGrid {...props} movies={undefined} />, {
+      route: "/addedOn/asc",
+    });
+    expect(screen.queryByText(/Movie/)).not.toBeInTheDocument();
     expect(
-      queryByRole("button", { name: "Add a Movie" })
+      screen.queryByRole("button", { name: "Add a Movie" })
     ).not.toBeInTheDocument();
   });
 
   it("should render the delete confirmation and call onRemoveMovie when deleting a movie", async ({
     props,
   }) => {
-    const { getByText, getByRole, queryByText } = renderWithProviders(
-      <ListGrid {...props} />,
-      {
-        route: "/addedOn/asc",
-      }
-    );
+    renderWithProviders(<ListGrid {...props} />, {
+      route: "/addedOn/asc",
+    });
 
-    fireEvent.click(getByText("Movie 1"));
-    expect(getByText("'Movie 1' will be removed")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Movie 1"));
+    expect(screen.getByText("'Movie 1' will be removed")).toBeInTheDocument();
 
-    fireEvent.click(getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(props.onRemoveMovie).toHaveBeenCalledWith(props.movies[0]);
-    expect(queryByText("'Movie 1' will be removed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("'Movie 1' will be removed")
+    ).not.toBeInTheDocument();
   });
 
   it("should render the delete confirmation and cancel correctly when deleting a movie", async ({
     props,
   }) => {
-    const { getByText, getByRole, queryByText } = renderWithProviders(
-      <ListGrid {...props} />,
-      { route: "/addedOn/asc" }
-    );
+    renderWithProviders(<ListGrid {...props} />, { route: "/addedOn/asc" });
 
-    fireEvent.click(getByText("Movie 1"));
-    expect(getByText("'Movie 1' will be removed")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Movie 1"));
+    expect(screen.getByText("'Movie 1' will be removed")).toBeInTheDocument();
 
-    fireEvent.click(getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(props.onRemoveMovie).not.toHaveBeenCalled();
-    expect(queryByText("'Movie 1' will be removed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("'Movie 1' will be removed")
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
@@ -29,37 +29,35 @@ describe("list-grid", () => {
     };
   });
 
-  it("should render the addedOn list", async ({ props }) => {
+  it("should render the addedOn list", ({ props }) => {
     renderWithProviders(<ListGrid {...props} />, {
       route: "/addedOn/asc",
     });
     expect(screen.getByTestId("addedOn")).toBeInTheDocument();
   });
 
-  it("should render the title list", async ({ props }) => {
+  it("should render the title list", ({ props }) => {
     renderWithProviders(<ListGrid {...props} />, {
       route: "/title/asc",
     });
     expect(screen.getByTestId("title")).toBeInTheDocument();
   });
 
-  it("should render the runtime list", async ({ props }) => {
+  it("should render the runtime list", ({ props }) => {
     renderWithProviders(<ListGrid {...props} />, {
       route: "/runtime/asc",
     });
     expect(screen.getByTestId("runtime")).toBeInTheDocument();
   });
 
-  it("should render the genre list", async ({ props }) => {
+  it("should render the genre list", ({ props }) => {
     renderWithProviders(<ListGrid {...props} />, {
       route: "/genre/asc",
     });
     expect(screen.getByTestId("genre")).toBeInTheDocument();
   });
 
-  it("should render the empty list when there are no movies", async ({
-    props,
-  }) => {
+  it("should render the empty list when there are no movies", ({ props }) => {
     renderWithProviders(<ListGrid {...props} movies={[]} />, {
       route: "/addedOn/asc",
     });
@@ -68,7 +66,7 @@ describe("list-grid", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render null when movies is undefined", async ({ props }) => {
+  it("should render null when movies is undefined", ({ props }) => {
     renderWithProviders(<ListGrid {...props} movies={undefined} />, {
       route: "/addedOn/asc",
     });

--- a/packages/web/src/components/app/components/list/components/ratings/ratings.test.jsx
+++ b/packages/web/src/components/app/components/list/components/ratings/ratings.test.jsx
@@ -1,10 +1,10 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { ratingsSource } from "md4k-constants";
 import Ratings from "./ratings";
 
 describe("ratings", () => {
   it("should render the ratings correctly", () => {
-    const { getByText, getByAltText } = render(
+    render(
       <Ratings
         ratings={{
           id: "tt0120737",
@@ -14,20 +14,24 @@ describe("ratings", () => {
         }}
       />
     );
-    expect(getByAltText(ratingsSource.IMDB)).toBeInTheDocument();
-    expect(getByText("88%")).toBeInTheDocument();
-    expect(getByAltText(ratingsSource.ROTTEN_TOMATOES)).toBeInTheDocument();
-    expect(getByText("91%")).toBeInTheDocument();
-    expect(getByAltText(ratingsSource.METACRITIC)).toBeInTheDocument();
-    expect(getByText("92%")).toBeInTheDocument();
+    expect(screen.getByAltText(ratingsSource.IMDB)).toBeInTheDocument();
+    expect(screen.getByText("88%")).toBeInTheDocument();
+    expect(
+      screen.getByAltText(ratingsSource.ROTTEN_TOMATOES)
+    ).toBeInTheDocument();
+    expect(screen.getByText("91%")).toBeInTheDocument();
+    expect(screen.getByAltText(ratingsSource.METACRITIC)).toBeInTheDocument();
+    expect(screen.getByText("92%")).toBeInTheDocument();
   });
 
   it("should render null when no ratings are provided", () => {
-    const { queryByAltText } = render(<Ratings />);
-    expect(queryByAltText(ratingsSource.IMDB)).not.toBeInTheDocument();
+    render(<Ratings />);
+    expect(screen.queryByAltText(ratingsSource.IMDB)).not.toBeInTheDocument();
     expect(
-      queryByAltText(ratingsSource.ROTTEN_TOMATOES)
+      screen.queryByAltText(ratingsSource.ROTTEN_TOMATOES)
     ).not.toBeInTheDocument();
-    expect(queryByAltText(ratingsSource.METACRITIC)).not.toBeInTheDocument();
+    expect(
+      screen.queryByAltText(ratingsSource.METACRITIC)
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/list/components/toast/toast.test.jsx
+++ b/packages/web/src/components/app/components/list/components/toast/toast.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Toast from "./toast";
 import { vi } from "vitest";
 
@@ -13,26 +13,26 @@ describe("toast", () => {
   });
 
   it("should render the toast correctly", ({ props }) => {
-    const { getByText, getByRole, getByTestId } = render(<Toast {...props} />);
+    render(<Toast {...props} />);
 
-    expect(getByText("Test Message")).toBeInTheDocument();
-    expect(getByRole("button", { name: "UNDO" })).toBeInTheDocument();
-    expect(getByTestId("CloseIcon")).toBeInTheDocument();
+    expect(screen.getByText("Test Message")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "UNDO" })).toBeInTheDocument();
+    expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
   });
 
   it("should call undo", ({ props }) => {
-    const { getByRole } = render(<Toast {...props} />);
+    render(<Toast {...props} />);
 
-    expect(getByRole("button", { name: "UNDO" })).toBeInTheDocument();
-    fireEvent.click(getByRole("button", { name: "UNDO" }));
+    expect(screen.getByRole("button", { name: "UNDO" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "UNDO" }));
     expect(props.onUndo).toHaveBeenCalled();
   });
 
   it("should call close", ({ props }) => {
-    const { getByTestId } = render(<Toast {...props} />);
+    render(<Toast {...props} />);
 
-    expect(getByTestId("CloseIcon")).toBeInTheDocument();
-    fireEvent.click(getByTestId("CloseIcon"));
+    expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("CloseIcon"));
     expect(props.onClose).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/toast/toast.test.jsx
+++ b/packages/web/src/components/app/components/list/components/toast/toast.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Toast from "./toast";
 import { vi } from "vitest";
 
@@ -20,19 +20,19 @@ describe("toast", () => {
     expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
   });
 
-  it("should call undo", ({ props }) => {
+  it("should call undo", async ({ props, user }) => {
     render(<Toast {...props} />);
 
     expect(screen.getByRole("button", { name: "UNDO" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "UNDO" }));
+    await user.click(screen.getByRole("button", { name: "UNDO" }));
     expect(props.onUndo).toHaveBeenCalled();
   });
 
-  it("should call close", ({ props }) => {
+  it("should call close", async ({ props, user }) => {
     render(<Toast {...props} />);
 
     expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("CloseIcon"));
+    await user.click(screen.getByTestId("CloseIcon"));
     expect(props.onClose).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/list/components/toast/toast.test.jsx
+++ b/packages/web/src/components/app/components/list/components/toast/toast.test.jsx
@@ -3,10 +3,8 @@ import Toast from "./toast";
 import { vi } from "vitest";
 
 describe("toast", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       open: true,
       onClose: vi.fn(),
       onUndo: vi.fn(),
@@ -14,7 +12,7 @@ describe("toast", () => {
     };
   });
 
-  it("should render the toast correctly", () => {
+  it("should render the toast correctly", ({ props }) => {
     const { getByText, getByRole, getByTestId } = render(<Toast {...props} />);
 
     expect(getByText("Test Message")).toBeInTheDocument();
@@ -22,7 +20,7 @@ describe("toast", () => {
     expect(getByTestId("CloseIcon")).toBeInTheDocument();
   });
 
-  it("should call undo", () => {
+  it("should call undo", ({ props }) => {
     const { getByRole } = render(<Toast {...props} />);
 
     expect(getByRole("button", { name: "UNDO" })).toBeInTheDocument();
@@ -30,7 +28,7 @@ describe("toast", () => {
     expect(props.onUndo).toHaveBeenCalled();
   });
 
-  it("should call close", () => {
+  it("should call close", ({ props }) => {
     const { getByTestId } = render(<Toast {...props} />);
 
     expect(getByTestId("CloseIcon")).toBeInTheDocument();

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import MoviePoster from "./movie-poster";
 import { vi } from "vitest";
 import * as useIntersectionObserverModule from "./hooks/use-intersection-observer";
@@ -89,15 +89,21 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should invoke the handler onClick when provided", ({ props }) => {
+  it("should invoke the handler onClick when provided", async ({
+    props,
+    user,
+  }) => {
     render(<MoviePoster {...props} />);
-    fireEvent.click(screen.getByLabelText(/Bourne.*Poster/));
+    await user.click(screen.getByLabelText(/Bourne.*Poster/));
     expect(props.onClick).toHaveBeenCalled();
   });
 
-  it("should not invoke the handler onClick when not provided", ({ props }) => {
+  it("should not invoke the handler onClick when not provided", async ({
+    props,
+    user,
+  }) => {
     render(<MoviePoster {...props} onClick={undefined} />);
-    fireEvent.click(screen.getByLabelText(/Bourne.*Poster/));
+    await user.click(screen.getByLabelText(/Bourne.*Poster/));
     expect(props.onClick).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import MoviePoster from "./movie-poster";
 import { vi } from "vitest";
 import * as useIntersectionObserverModule from "./hooks/use-intersection-observer";
@@ -39,19 +39,19 @@ describe("movie-poster", () => {
   });
 
   it("should render the correct height and width ratio", ({ props }) => {
-    const { getByLabelText } = render(<MoviePoster {...props} height={1000} />);
-    expect(getByLabelText(/Bourne.*Poster/)).toHaveStyle({
+    render(<MoviePoster {...props} height={1000} />);
+    expect(screen.getByLabelText(/Bourne.*Poster/)).toHaveStyle({
       width: "640px",
       height: "1000px",
     });
   });
 
   it("should render the poster when a url exists in the movie", ({ props }) => {
-    const { getByTestId, getByText } = render(<MoviePoster {...props} />);
-    expect(getByTestId("poster")).toHaveStyle({
+    render(<MoviePoster {...props} />);
+    expect(screen.getByTestId("poster")).toHaveStyle({
       "background-image": `url(${props.movie.poster})`,
     });
-    expect(getByText(/Bourne/)).toBeInTheDocument();
+    expect(screen.getByText(/Bourne/)).toBeInTheDocument();
   });
 
   it("should render the placeholder when the poster is not intersecting the viewport", ({
@@ -65,52 +65,46 @@ describe("movie-poster", () => {
         visible: false,
       });
 
-    const { getByTestId, getByText } = render(<MoviePoster {...props} />);
+    render(<MoviePoster {...props} />);
 
-    expect(getByTestId("poster")).toHaveStyle({
+    expect(screen.getByTestId("poster")).toHaveStyle({
       "background-image": "",
     });
-    expect(getByText(/Bourne/)).toBeInTheDocument();
+    expect(screen.getByText(/Bourne/)).toBeInTheDocument();
   });
 
   it("should be active when an onClick handler is provided", ({ props }) => {
-    const { getByTestId } = render(<MoviePoster {...props} />);
+    render(<MoviePoster {...props} />);
 
-    expect(getByTestId("poster")).toHaveStyle({
+    expect(screen.getByTestId("poster")).toHaveStyle({
       cursor: "pointer",
     });
   });
 
   it("should not be active when an onClick handler is omitted", ({ props }) => {
-    const { getByTestId } = render(
-      <MoviePoster {...props} onClick={undefined} />
-    );
+    render(<MoviePoster {...props} onClick={undefined} />);
 
-    expect(getByTestId("poster")).not.toHaveStyle({
+    expect(screen.getByTestId("poster")).not.toHaveStyle({
       cursor: "pointer",
     });
   });
 
   it("should invoke the handler onClick when provided", ({ props }) => {
-    const { getByLabelText } = render(<MoviePoster {...props} />);
-    fireEvent.click(getByLabelText(/Bourne.*Poster/));
+    render(<MoviePoster {...props} />);
+    fireEvent.click(screen.getByLabelText(/Bourne.*Poster/));
     expect(props.onClick).toHaveBeenCalled();
   });
 
   it("should not invoke the handler onClick when not provided", ({ props }) => {
-    const { getByLabelText } = render(
-      <MoviePoster {...props} onClick={undefined} />
-    );
-    fireEvent.click(getByLabelText(/Bourne.*Poster/));
+    render(<MoviePoster {...props} onClick={undefined} />);
+    fireEvent.click(screen.getByLabelText(/Bourne.*Poster/));
     expect(props.onClick).not.toHaveBeenCalled();
   });
 
   it("should dim the poster when locked", ({ props }) => {
-    const { getByLabelText } = render(
-      <MoviePoster {...props} movie={{ ...props.movie, locked: true }} />
-    );
+    render(<MoviePoster {...props} movie={{ ...props.movie, locked: true }} />);
 
-    expect(getByLabelText(/Bourne.*Poster/)).toHaveStyle({
+    expect(screen.getByLabelText(/Bourne.*Poster/)).toHaveStyle({
       opacity: "0.3",
     });
   });
@@ -118,27 +112,27 @@ describe("movie-poster", () => {
   it("should not dim the poster when locked but noLock is passed", ({
     props,
   }) => {
-    const { getByLabelText } = render(
+    render(
       <MoviePoster {...props} movie={{ ...props.movie, locked: true }} noLock />
     );
 
-    expect(getByLabelText(/Bourne.*Poster/)).toHaveStyle({
+    expect(screen.getByLabelText(/Bourne.*Poster/)).toHaveStyle({
       opacity: "1",
     });
   });
 
   it("should be relatively positioned when noRel is false", ({ props }) => {
-    const { getByLabelText } = render(<MoviePoster {...props} />);
+    render(<MoviePoster {...props} />);
 
-    expect(getByLabelText(/Bourne.*Poster/)).toHaveStyle({
+    expect(screen.getByLabelText(/Bourne.*Poster/)).toHaveStyle({
       position: "relative",
     });
   });
 
   it("should not be relatively positioned when noRel is true", ({ props }) => {
-    const { getByLabelText } = render(<MoviePoster {...props} noRel />);
+    render(<MoviePoster {...props} noRel />);
 
-    expect(getByLabelText(/Bourne.*Poster/)).not.toHaveStyle({
+    expect(screen.getByLabelText(/Bourne.*Poster/)).not.toHaveStyle({
       position: "relative",
     });
   });

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
@@ -11,10 +11,8 @@ vi.mock("./hooks/use-intersection-observer", () => ({
 }));
 
 describe("movie-poster", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       movie: {
         id: "8502fd8b-165e-4239-965f-b46f8d523829",
         title: "The Bourne Identity",
@@ -40,7 +38,7 @@ describe("movie-poster", () => {
     };
   });
 
-  it("should render the correct height and width ratio", () => {
+  it("should render the correct height and width ratio", ({ props }) => {
     const { getByLabelText } = render(<MoviePoster {...props} height={1000} />);
     expect(getByLabelText(/Bourne.*Poster/)).toHaveStyle({
       width: "640px",
@@ -48,7 +46,7 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should render the poster when a url exists in the movie", () => {
+  it("should render the poster when a url exists in the movie", ({ props }) => {
     const { getByTestId, getByText } = render(<MoviePoster {...props} />);
     expect(getByTestId("poster")).toHaveStyle({
       "background-image": `url(${props.movie.poster})`,
@@ -56,7 +54,9 @@ describe("movie-poster", () => {
     expect(getByText(/Bourne/)).toBeInTheDocument();
   });
 
-  it("should render the placeholder when the poster is not intersecting the viewport", () => {
+  it("should render the placeholder when the poster is not intersecting the viewport", ({
+    props,
+  }) => {
     // eslint-disable-next-line no-import-assign
     useIntersectionObserverModule.useIntersectionObserver = vi
       .fn()
@@ -73,7 +73,7 @@ describe("movie-poster", () => {
     expect(getByText(/Bourne/)).toBeInTheDocument();
   });
 
-  it("should be active when an onClick handler is provided", () => {
+  it("should be active when an onClick handler is provided", ({ props }) => {
     const { getByTestId } = render(<MoviePoster {...props} />);
 
     expect(getByTestId("poster")).toHaveStyle({
@@ -81,7 +81,7 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should not be active when an onClick handler is omitted", () => {
+  it("should not be active when an onClick handler is omitted", ({ props }) => {
     const { getByTestId } = render(
       <MoviePoster {...props} onClick={undefined} />
     );
@@ -91,13 +91,13 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should invoke the handler onClick when provided", () => {
+  it("should invoke the handler onClick when provided", ({ props }) => {
     const { getByLabelText } = render(<MoviePoster {...props} />);
     fireEvent.click(getByLabelText(/Bourne.*Poster/));
     expect(props.onClick).toHaveBeenCalled();
   });
 
-  it("should not invoke the handler onClick when not provided", () => {
+  it("should not invoke the handler onClick when not provided", ({ props }) => {
     const { getByLabelText } = render(
       <MoviePoster {...props} onClick={undefined} />
     );
@@ -105,7 +105,7 @@ describe("movie-poster", () => {
     expect(props.onClick).not.toHaveBeenCalled();
   });
 
-  it("should dim the poster when locked", () => {
+  it("should dim the poster when locked", ({ props }) => {
     const { getByLabelText } = render(
       <MoviePoster {...props} movie={{ ...props.movie, locked: true }} />
     );
@@ -115,7 +115,9 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should not dim the poster when locked but noLock is passed", () => {
+  it("should not dim the poster when locked but noLock is passed", ({
+    props,
+  }) => {
     const { getByLabelText } = render(
       <MoviePoster {...props} movie={{ ...props.movie, locked: true }} noLock />
     );
@@ -125,7 +127,7 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should be relatively positioned when noRel is false", () => {
+  it("should be relatively positioned when noRel is false", ({ props }) => {
     const { getByLabelText } = render(<MoviePoster {...props} />);
 
     expect(getByLabelText(/Bourne.*Poster/)).toHaveStyle({
@@ -133,7 +135,7 @@ describe("movie-poster", () => {
     });
   });
 
-  it("should not be relatively positioned when noRel is true", () => {
+  it("should not be relatively positioned when noRel is true", ({ props }) => {
     const { getByLabelText } = render(<MoviePoster {...props} noRel />);
 
     expect(getByLabelText(/Bourne.*Poster/)).not.toHaveStyle({

--- a/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
@@ -1,5 +1,5 @@
 import DbSelect from "./db-select";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import {
   GET_MOVIES_MOCK_FAMILY,
@@ -14,59 +14,60 @@ vi.mock("react-router-dom", async () => {
 
 describe("db-select", () => {
   it("should render the list with the active list when closed", async () => {
-    const { findByLabelText } = renderWithProviders(<DbSelect />);
-    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
-    expect(await findByLabelText(/Saturday/)).toBeInTheDocument();
+    renderWithProviders(<DbSelect />);
+    expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
+    expect(await screen.findByLabelText(/Saturday/)).toBeInTheDocument();
   });
 
   it("should render the list with the available options and an option for making a new list", async () => {
-    const { getByRole, findByLabelText } = renderWithProviders(<DbSelect />);
+    renderWithProviders(<DbSelect />);
 
-    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
 
     fireEvent.mouseDown(
-      getByRole("button", { name: "Saturday Night", expanded: false })
+      screen.getByRole("button", { name: "Saturday Night", expanded: false })
     );
 
     expect(
-      getByRole("option", { name: /Saturday/, selected: true })
+      screen.getByRole("option", { name: /Saturday/, selected: true })
     ).toBeInTheDocument();
     expect(
-      getByRole("option", { name: /Family/, selected: false })
+      screen.getByRole("option", { name: /Family/, selected: false })
     ).toBeInTheDocument();
     expect(
-      getByRole("option", { name: /New List/, selected: false })
+      screen.getByRole("option", { name: /New List/, selected: false })
     ).toBeInTheDocument();
   });
 
   it("should push to the home page and set a new list when clicking on an existing list", async () => {
-    const { getByRole, getByLabelText, findByLabelText } = renderWithProviders(
-      <DbSelect />,
-      {
-        mocks: [GET_MOVIES_MOCK_FAMILY],
-      }
-    );
+    renderWithProviders(<DbSelect />, {
+      mocks: [GET_MOVIES_MOCK_FAMILY],
+    });
 
-    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
 
     fireEvent.mouseDown(
-      getByRole("button", { name: /Saturday/, expanded: false })
+      screen.getByRole("button", { name: /Saturday/, expanded: false })
     );
-    fireEvent.click(getByRole("option", { name: /Family/, selected: false }));
+    fireEvent.click(
+      screen.getByRole("option", { name: /Family/, selected: false })
+    );
 
     expect(navigateMock).toHaveBeenCalledWith("/");
-    expect(getByLabelText(/Family/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Family/)).toBeInTheDocument();
   });
 
   it("should push to the create page", async () => {
-    const { getByRole, findByLabelText } = renderWithProviders(<DbSelect />);
+    renderWithProviders(<DbSelect />);
 
-    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
 
     fireEvent.mouseDown(
-      getByRole("button", { name: /Saturday/, expanded: false })
+      screen.getByRole("button", { name: /Saturday/, expanded: false })
     );
-    fireEvent.click(getByRole("option", { name: /New List/, selected: false }));
+    fireEvent.click(
+      screen.getByRole("option", { name: /New List/, selected: false })
+    );
 
     expect(navigateMock).toHaveBeenCalledWith("/create");
   });

--- a/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
@@ -14,7 +14,7 @@ vi.mock("react-router-dom", async () => {
 
 describe("db-select", () => {
   it("should render the list with the active list when closed", async () => {
-    const { getByLabelText } = await renderWithProviders(<DbSelect />);
+    const { getByLabelText } = renderWithProviders(<DbSelect />);
 
     await waitFor(() =>
       expect(getByLabelText("Choose a List")).toBeInTheDocument()
@@ -24,9 +24,7 @@ describe("db-select", () => {
   });
 
   it("should render the list with the available options and an option for making a new list", async () => {
-    const { getByRole, getByLabelText } = await renderWithProviders(
-      <DbSelect />
-    );
+    const { getByRole, getByLabelText } = renderWithProviders(<DbSelect />);
 
     await waitFor(() =>
       expect(getByLabelText("Choose a List")).toBeInTheDocument()
@@ -48,12 +46,9 @@ describe("db-select", () => {
   });
 
   it("should push to the home page and set a new list when clicking on an existing list", async () => {
-    const { getByRole, getByLabelText } = await renderWithProviders(
-      <DbSelect />,
-      {
-        mocks: [GET_MOVIES_MOCK_FAMILY],
-      }
-    );
+    const { getByRole, getByLabelText } = renderWithProviders(<DbSelect />, {
+      mocks: [GET_MOVIES_MOCK_FAMILY],
+    });
 
     await waitFor(() =>
       expect(getByLabelText("Choose a List")).toBeInTheDocument()
@@ -69,9 +64,7 @@ describe("db-select", () => {
   });
 
   it("should push to the create page", async () => {
-    const { getByRole, getByLabelText } = await renderWithProviders(
-      <DbSelect />
-    );
+    const { getByRole, getByLabelText } = renderWithProviders(<DbSelect />);
 
     await waitFor(() =>
       expect(getByLabelText("Choose a List")).toBeInTheDocument()

--- a/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
@@ -1,5 +1,5 @@
 import DbSelect from "./db-select";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 import { vi } from "vitest";
 import {
   GET_MOVIES_MOCK_FAMILY,
@@ -14,21 +14,15 @@ vi.mock("react-router-dom", async () => {
 
 describe("db-select", () => {
   it("should render the list with the active list when closed", async () => {
-    const { getByLabelText } = renderWithProviders(<DbSelect />);
-
-    await waitFor(() =>
-      expect(getByLabelText("Choose a List")).toBeInTheDocument()
-    );
-
-    expect(getByLabelText(/Saturday/)).toBeInTheDocument();
+    const { findByLabelText } = renderWithProviders(<DbSelect />);
+    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
+    expect(await findByLabelText(/Saturday/)).toBeInTheDocument();
   });
 
   it("should render the list with the available options and an option for making a new list", async () => {
-    const { getByRole, getByLabelText } = renderWithProviders(<DbSelect />);
+    const { getByRole, findByLabelText } = renderWithProviders(<DbSelect />);
 
-    await waitFor(() =>
-      expect(getByLabelText("Choose a List")).toBeInTheDocument()
-    );
+    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
 
     fireEvent.mouseDown(
       getByRole("button", { name: "Saturday Night", expanded: false })
@@ -46,13 +40,14 @@ describe("db-select", () => {
   });
 
   it("should push to the home page and set a new list when clicking on an existing list", async () => {
-    const { getByRole, getByLabelText } = renderWithProviders(<DbSelect />, {
-      mocks: [GET_MOVIES_MOCK_FAMILY],
-    });
-
-    await waitFor(() =>
-      expect(getByLabelText("Choose a List")).toBeInTheDocument()
+    const { getByRole, getByLabelText, findByLabelText } = renderWithProviders(
+      <DbSelect />,
+      {
+        mocks: [GET_MOVIES_MOCK_FAMILY],
+      }
     );
+
+    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
 
     fireEvent.mouseDown(
       getByRole("button", { name: /Saturday/, expanded: false })
@@ -64,11 +59,9 @@ describe("db-select", () => {
   });
 
   it("should push to the create page", async () => {
-    const { getByRole, getByLabelText } = renderWithProviders(<DbSelect />);
+    const { getByRole, findByLabelText } = renderWithProviders(<DbSelect />);
 
-    await waitFor(() =>
-      expect(getByLabelText("Choose a List")).toBeInTheDocument()
-    );
+    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
 
     fireEvent.mouseDown(
       getByRole("button", { name: /Saturday/, expanded: false })

--- a/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/db-select/db-select.test.jsx
@@ -1,5 +1,5 @@
 import DbSelect from "./db-select";
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 import {
   GET_MOVIES_MOCK_FAMILY,
@@ -19,12 +19,14 @@ describe("db-select", () => {
     expect(await screen.findByLabelText(/Saturday/)).toBeInTheDocument();
   });
 
-  it("should render the list with the available options and an option for making a new list", async () => {
+  it("should render the list with the available options and an option for making a new list", async ({
+    user,
+  }) => {
     renderWithProviders(<DbSelect />);
 
     expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
 
-    fireEvent.mouseDown(
+    await user.click(
       screen.getByRole("button", { name: "Saturday Night", expanded: false })
     );
 
@@ -39,17 +41,19 @@ describe("db-select", () => {
     ).toBeInTheDocument();
   });
 
-  it("should push to the home page and set a new list when clicking on an existing list", async () => {
+  it("should push to the home page and set a new list when clicking on an existing list", async ({
+    user,
+  }) => {
     renderWithProviders(<DbSelect />, {
       mocks: [GET_MOVIES_MOCK_FAMILY],
     });
 
     expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
 
-    fireEvent.mouseDown(
+    await user.click(
       screen.getByRole("button", { name: /Saturday/, expanded: false })
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole("option", { name: /Family/, selected: false })
     );
 
@@ -57,15 +61,15 @@ describe("db-select", () => {
     expect(screen.getByLabelText(/Family/)).toBeInTheDocument();
   });
 
-  it("should push to the create page", async () => {
+  it("should push to the create page", async ({ user }) => {
     renderWithProviders(<DbSelect />);
 
     expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
 
-    fireEvent.mouseDown(
+    await user.click(
       screen.getByRole("button", { name: /Saturday/, expanded: false })
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole("option", { name: /New List/, selected: false })
     );
 

--- a/packages/web/src/components/app/components/titlebar/components/logo/logo.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/logo/logo.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Logo from "./logo";
 import { vi } from "vitest";
 
@@ -9,9 +9,9 @@ vi.mock("react-router-dom", async () => {
 });
 
 describe("logo", () => {
-  it("should navigate to the root on click", () => {
+  it("should navigate to the root on click", async ({ user }) => {
     render(<Logo />);
-    fireEvent.click(screen.getByLabelText("Movie Decider 4000"));
+    await user.click(screen.getByLabelText("Movie Decider 4000"));
     expect(navigateMock).toBeCalledWith("/");
   });
 });

--- a/packages/web/src/components/app/components/titlebar/components/logo/logo.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/logo/logo.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Logo from "./logo";
 import { vi } from "vitest";
 
@@ -10,8 +10,8 @@ vi.mock("react-router-dom", async () => {
 
 describe("logo", () => {
   it("should navigate to the root on click", () => {
-    const { getByLabelText } = render(<Logo />);
-    fireEvent.click(getByLabelText("Movie Decider 4000"));
+    render(<Logo />);
+    fireEvent.click(screen.getByLabelText("Movie Decider 4000"));
     expect(navigateMock).toBeCalledWith("/");
   });
 });

--- a/packages/web/src/components/app/components/titlebar/components/nav-button/nav-button.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-button/nav-button.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import NavButton from "./nav-button";
 import { vi } from "vitest";
 
@@ -13,27 +13,29 @@ describe("nav-button", () => {
     vi.clearAllMocks();
   });
 
-  it("should navigate to the provided href", () => {
+  it("should navigate to the provided href", async ({ user }) => {
     render(<NavButton href="/test">Test Button</NavButton>);
-    fireEvent.click(screen.getByRole("button", { name: "Test Button" }));
+    await user.click(screen.getByRole("button", { name: "Test Button" }));
     expect(navigateMock).toBeCalledWith("/test");
   });
 
-  it("should call the provided onClick", () => {
+  it("should call the provided onClick", async ({ user }) => {
     const onClick = vi.fn();
     render(<NavButton onClick={onClick}>Test Button</NavButton>);
-    fireEvent.click(screen.getByRole("button", { name: "Test Button" }));
+    await user.click(screen.getByRole("button", { name: "Test Button" }));
     expect(onClick).toHaveBeenCalled();
   });
 
-  it("should prefer onClick over the href if both are provided", () => {
+  it("should prefer onClick over the href if both are provided", async ({
+    user,
+  }) => {
     const onClick = vi.fn();
     render(
       <NavButton herf="/test" onClick={onClick}>
         Test Button
       </NavButton>
     );
-    fireEvent.click(screen.getByRole("button", { name: "Test Button" }));
+    await user.click(screen.getByRole("button", { name: "Test Button" }));
     expect(onClick).toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });

--- a/packages/web/src/components/app/components/titlebar/components/nav-button/nav-button.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-button/nav-button.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import NavButton from "./nav-button";
 import { vi } from "vitest";
 
@@ -14,49 +14,45 @@ describe("nav-button", () => {
   });
 
   it("should navigate to the provided href", () => {
-    const { getByRole } = render(
-      <NavButton href="/test">Test Button</NavButton>
-    );
-    fireEvent.click(getByRole("button", { name: "Test Button" }));
+    render(<NavButton href="/test">Test Button</NavButton>);
+    fireEvent.click(screen.getByRole("button", { name: "Test Button" }));
     expect(navigateMock).toBeCalledWith("/test");
   });
 
   it("should call the provided onClick", () => {
     const onClick = vi.fn();
-    const { getByRole } = render(
-      <NavButton onClick={onClick}>Test Button</NavButton>
-    );
-    fireEvent.click(getByRole("button", { name: "Test Button" }));
+    render(<NavButton onClick={onClick}>Test Button</NavButton>);
+    fireEvent.click(screen.getByRole("button", { name: "Test Button" }));
     expect(onClick).toHaveBeenCalled();
   });
 
   it("should prefer onClick over the href if both are provided", () => {
     const onClick = vi.fn();
-    const { getByRole } = render(
+    render(
       <NavButton herf="/test" onClick={onClick}>
         Test Button
       </NavButton>
     );
-    fireEvent.click(getByRole("button", { name: "Test Button" }));
+    fireEvent.click(screen.getByRole("button", { name: "Test Button" }));
     expect(onClick).toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("should render the provided children", () => {
-    const { getByText } = render(
+    render(
       <NavButton herf="/test">
         <div>Content</div>
       </NavButton>
     );
-    expect(getByText("Content")).toBeInTheDocument();
+    expect(screen.getByText("Content")).toBeInTheDocument();
   });
 
   it("should pass through props to the button", () => {
-    const { getByLabelText } = render(
+    render(
       <NavButton herf="/test" aria-label="testButton">
         Test Button
       </NavButton>
     );
-    expect(getByLabelText("testButton")).toBeInTheDocument();
+    expect(screen.getByLabelText("testButton")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.test.jsx
@@ -1,33 +1,34 @@
 import NavFull from "./nav-full";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
+import { screen } from "@testing-library/dom";
 
 describe("nav-full", () => {
   it("should render the default nav options and list select component", async () => {
-    const { getByRole, findByLabelText } = renderWithProviders(<NavFull />);
-    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
-    expect(getByRole("button", { name: "Watched" })).toBeInTheDocument();
+    renderWithProviders(<NavFull />);
+    expect(await screen.findByLabelText("Choose a List")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Watched" })).toBeInTheDocument();
   });
 
   it("should render the 'pick' nav options", async () => {
-    const { findByRole } = renderWithProviders(<NavFull />, {
+    renderWithProviders(<NavFull />, {
       route: "/pick",
     });
 
     expect(
-      await findByRole("button", { name: "Return to Movies" })
+      await screen.findByRole("button", { name: "Return to Movies" })
     ).toBeInTheDocument();
     expect(
-      await findByRole("button", { name: "Pick Again" })
+      await screen.findByRole("button", { name: "Pick Again" })
     ).toBeInTheDocument();
   });
 
   it("should render the 'create' nav options", async () => {
-    const { findByRole } = renderWithProviders(<NavFull />, {
+    renderWithProviders(<NavFull />, {
       route: "/create",
     });
 
     expect(
-      await findByRole("button", { name: "Return to Movies" })
+      await screen.findByRole("button", { name: "Return to Movies" })
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.test.jsx
@@ -1,40 +1,33 @@
 import NavFull from "./nav-full";
-import { waitFor } from "@testing-library/react";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 
 describe("nav-full", () => {
   it("should render the default nav options and list select component", async () => {
-    const { getByRole, getByLabelText } = renderWithProviders(<NavFull />);
-
-    await waitFor(() => {
-      expect(getByLabelText("Choose a List")).toBeInTheDocument();
-    });
-
+    const { getByRole, findByLabelText } = renderWithProviders(<NavFull />);
+    expect(await findByLabelText("Choose a List")).toBeInTheDocument();
     expect(getByRole("button", { name: "Watched" })).toBeInTheDocument();
   });
 
   it("should render the 'pick' nav options", async () => {
-    const { getByRole } = renderWithProviders(<NavFull />, {
+    const { findByRole } = renderWithProviders(<NavFull />, {
       route: "/pick",
     });
 
-    await waitFor(() => {
-      expect(
-        getByRole("button", { name: "Return to Movies" })
-      ).toBeInTheDocument();
-      expect(getByRole("button", { name: "Pick Again" })).toBeInTheDocument();
-    });
+    expect(
+      await findByRole("button", { name: "Return to Movies" })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("button", { name: "Pick Again" })
+    ).toBeInTheDocument();
   });
 
   it("should render the 'create' nav options", async () => {
-    const { getByRole } = renderWithProviders(<NavFull />, {
+    const { findByRole } = renderWithProviders(<NavFull />, {
       route: "/create",
     });
 
-    await waitFor(() =>
-      expect(
-        getByRole("button", { name: "Return to Movies" })
-      ).toBeInTheDocument()
-    );
+    expect(
+      await findByRole("button", { name: "Return to Movies" })
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.test.jsx
@@ -4,9 +4,7 @@ import { renderWithProviders } from "../../../../../../utils/render-with-provide
 
 describe("nav-full", () => {
   it("should render the default nav options and list select component", async () => {
-    const { getByRole, getByLabelText } = await renderWithProviders(
-      <NavFull />
-    );
+    const { getByRole, getByLabelText } = renderWithProviders(<NavFull />);
 
     await waitFor(() => {
       expect(getByLabelText("Choose a List")).toBeInTheDocument();
@@ -16,7 +14,7 @@ describe("nav-full", () => {
   });
 
   it("should render the 'pick' nav options", async () => {
-    const { getByRole } = await renderWithProviders(<NavFull />, {
+    const { getByRole } = renderWithProviders(<NavFull />, {
       route: "/pick",
     });
 
@@ -29,7 +27,7 @@ describe("nav-full", () => {
   });
 
   it("should render the 'create' nav options", async () => {
-    const { getByRole } = await renderWithProviders(<NavFull />, {
+    const { getByRole } = renderWithProviders(<NavFull />, {
       route: "/create",
     });
 

--- a/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
@@ -3,13 +3,8 @@ import NavHamburger from "./nav-hamburger";
 import { MemoryRouter } from "react-router-dom";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import { AppContext } from "../../../../../../context/app-context";
-import userEvent from "@testing-library/user-event";
 
 describe("nav-hamburger", () => {
-  beforeEach((context) => {
-    context.user = userEvent.setup();
-  });
-
   it("should render the default nav options", async ({ user }) => {
     renderWithProviders(<NavHamburger />);
 

--- a/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
@@ -1,18 +1,23 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import NavHamburger from "./nav-hamburger";
 import { MemoryRouter } from "react-router-dom";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import { AppContext } from "../../../../../../context/app-context";
+import userEvent from "@testing-library/user-event";
 
 describe("nav-hamburger", () => {
-  it("should render the default nav options", async () => {
-    const { getByTestId, findByRole } = renderWithProviders(<NavHamburger />);
+  beforeEach((context) => {
+    context.user = userEvent.setup();
+  });
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument();
-    });
+  it("should render the default nav options", async ({ user }) => {
+    const { getByTestId, findByTestId, findByRole } = renderWithProviders(
+      <NavHamburger />
+    );
 
-    fireEvent.click(getByTestId("MenuIcon"));
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
+
+    await user.click(getByTestId("MenuIcon"));
 
     expect(
       await findByRole("menuitem", { name: "Watched" })
@@ -28,16 +33,17 @@ describe("nav-hamburger", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the 'watched' nav options", async () => {
-    const { getByTestId, findByRole } = renderWithProviders(<NavHamburger />, {
-      route: "/watched",
-    });
+  it("should render the 'watched' nav options", async ({ user }) => {
+    const { getByTestId, findByTestId, findByRole } = renderWithProviders(
+      <NavHamburger />,
+      {
+        route: "/watched",
+      }
+    );
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument();
-    });
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("MenuIcon"));
+    await user.click(getByTestId("MenuIcon"));
 
     expect(
       await findByRole("menuitem", { name: "Movies" })
@@ -53,13 +59,13 @@ describe("nav-hamburger", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the 'pick' nav options", async () => {
+  it("should render the 'pick' nav options", async ({ user }) => {
     const { getByTestId, getByRole, findByTestId, findByRole } =
       renderWithProviders(<NavHamburger />, { route: "/pick" });
 
     expect(await findByTestId("MenuIcon")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("MenuIcon"));
+    await user.click(getByTestId("MenuIcon"));
 
     expect(getByRole("menuitem", { name: "Pick again" })).toBeInTheDocument();
     expect(getByRole("menuitem", { name: "Movies" })).toBeInTheDocument();
@@ -75,16 +81,17 @@ describe("nav-hamburger", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the default 'create' nav options", async () => {
-    const { getByTestId, getByRole } = renderWithProviders(<NavHamburger />, {
-      route: "/create",
-    });
+  it("should render the default 'create' nav options", async ({ user }) => {
+    const { getByTestId, findByTestId, getByRole } = renderWithProviders(
+      <NavHamburger />,
+      {
+        route: "/create",
+      }
+    );
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument();
-    });
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("MenuIcon"));
+    await user.click(getByTestId("MenuIcon"));
 
     expect(getByRole("menuitem", { name: "Movies" })).toBeInTheDocument();
   });
@@ -103,26 +110,17 @@ describe("nav-hamburger", () => {
     });
   });
 
-  it("should close when clicking outside", async () => {
-    const { getByTestId, getByRole, queryByRole } = renderWithProviders(
-      <NavHamburger />
-    );
+  it("should close when clicking outside", async ({ user }) => {
+    const { getByTestId, findByTestId, getByRole, queryByRole } =
+      renderWithProviders(<NavHamburger />);
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument();
-    });
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
 
-    fireEvent.click(getByTestId("MenuIcon"));
+    await user.click(getByTestId("MenuIcon"));
 
     expect(getByRole("menuitem", { name: "Watched" })).toBeInTheDocument();
 
-    // Couldn't figure out a better way to make this work.
-    // There's some discussion here but seems the click away listener is not "armed" immediately due to a react bug.
-    // I've needed to use a wait here to make sure the click away is ready.
-    // https://github.com/mui/material-ui/issues/24783#issuecomment-774054038
-    await waitFor(() => new Promise((r) => setTimeout(r, 1)));
-
-    fireEvent.click(document);
+    await user.click(document.body);
 
     await waitFor(() =>
       expect(

--- a/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
@@ -6,9 +6,7 @@ import { AppContext } from "../../../../../../context/app-context";
 
 describe("nav-hamburger", () => {
   it("should render the default nav options", async () => {
-    const { getByTestId, getByRole } = await renderWithProviders(
-      <NavHamburger />
-    );
+    const { getByTestId, findByRole } = renderWithProviders(<NavHamburger />);
 
     await waitFor(() => {
       expect(getByTestId("MenuIcon")).toBeInTheDocument();
@@ -16,17 +14,24 @@ describe("nav-hamburger", () => {
 
     fireEvent.click(getByTestId("MenuIcon"));
 
-    expect(getByRole("menuitem", { name: "Watched" })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /Saturday/ })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /Family/ })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /New List/ })).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: "Watched" })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /Saturday/ })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /Family/ })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /New List/ })
+    ).toBeInTheDocument();
   });
 
   it("should render the 'watched' nav options", async () => {
-    const { getByTestId, getByRole } = await renderWithProviders(
-      <NavHamburger />,
-      { route: "/watched" }
-    );
+    const { getByTestId, findByRole } = renderWithProviders(<NavHamburger />, {
+      route: "/watched",
+    });
 
     await waitFor(() => {
       expect(getByTestId("MenuIcon")).toBeInTheDocument();
@@ -34,37 +39,46 @@ describe("nav-hamburger", () => {
 
     fireEvent.click(getByTestId("MenuIcon"));
 
-    expect(getByRole("menuitem", { name: "Movies" })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /Saturday/ })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /Family/ })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /New List/ })).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: "Movies" })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /Saturday/ })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /Family/ })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /New List/ })
+    ).toBeInTheDocument();
   });
 
   it("should render the 'pick' nav options", async () => {
-    const { getByTestId, getByRole } = await renderWithProviders(
-      <NavHamburger />,
-      { route: "/pick" }
-    );
+    const { getByTestId, getByRole, findByTestId, findByRole } =
+      renderWithProviders(<NavHamburger />, { route: "/pick" });
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument();
-    });
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
 
     fireEvent.click(getByTestId("MenuIcon"));
 
     expect(getByRole("menuitem", { name: "Pick again" })).toBeInTheDocument();
     expect(getByRole("menuitem", { name: "Movies" })).toBeInTheDocument();
     expect(getByRole("menuitem", { name: "Watched" })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /Saturday/ })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /Family/ })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: /New List/ })).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /Saturday/ })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /Family/ })
+    ).toBeInTheDocument();
+    expect(
+      await findByRole("menuitem", { name: /New List/ })
+    ).toBeInTheDocument();
   });
 
   it("should render the default 'create' nav options", async () => {
-    const { getByTestId, getByRole } = await renderWithProviders(
-      <NavHamburger />,
-      { route: "/create" }
-    );
+    const { getByTestId, getByRole } = renderWithProviders(<NavHamburger />, {
+      route: "/create",
+    });
 
     await waitFor(() => {
       expect(getByTestId("MenuIcon")).toBeInTheDocument();
@@ -90,7 +104,7 @@ describe("nav-hamburger", () => {
   });
 
   it("should close when clicking outside", async () => {
-    const { getByTestId, getByRole, queryByRole } = await renderWithProviders(
+    const { getByTestId, getByRole, queryByRole } = renderWithProviders(
       <NavHamburger />
     );
 

--- a/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.test.jsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import NavHamburger from "./nav-hamburger";
 import { MemoryRouter } from "react-router-dom";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
@@ -11,93 +11,92 @@ describe("nav-hamburger", () => {
   });
 
   it("should render the default nav options", async ({ user }) => {
-    const { getByTestId, findByTestId, findByRole } = renderWithProviders(
-      <NavHamburger />
-    );
+    renderWithProviders(<NavHamburger />);
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument();
 
-    await user.click(getByTestId("MenuIcon"));
+    await user.click(screen.getByTestId("MenuIcon"));
 
     expect(
-      await findByRole("menuitem", { name: "Watched" })
+      await screen.findByRole("menuitem", { name: "Watched" })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /Saturday/ })
+      await screen.findByRole("menuitem", { name: /Saturday/ })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /Family/ })
+      await screen.findByRole("menuitem", { name: /Family/ })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /New List/ })
+      await screen.findByRole("menuitem", { name: /New List/ })
     ).toBeInTheDocument();
   });
 
   it("should render the 'watched' nav options", async ({ user }) => {
-    const { getByTestId, findByTestId, findByRole } = renderWithProviders(
-      <NavHamburger />,
-      {
-        route: "/watched",
-      }
-    );
+    renderWithProviders(<NavHamburger />, {
+      route: "/watched",
+    });
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument();
 
-    await user.click(getByTestId("MenuIcon"));
+    await user.click(screen.getByTestId("MenuIcon"));
 
     expect(
-      await findByRole("menuitem", { name: "Movies" })
+      await screen.findByRole("menuitem", { name: "Movies" })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /Saturday/ })
+      await screen.findByRole("menuitem", { name: /Saturday/ })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /Family/ })
+      await screen.findByRole("menuitem", { name: /Family/ })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /New List/ })
+      await screen.findByRole("menuitem", { name: /New List/ })
     ).toBeInTheDocument();
   });
 
   it("should render the 'pick' nav options", async ({ user }) => {
-    const { getByTestId, getByRole, findByTestId, findByRole } =
-      renderWithProviders(<NavHamburger />, { route: "/pick" });
+    renderWithProviders(<NavHamburger />, { route: "/pick" });
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument();
 
-    await user.click(getByTestId("MenuIcon"));
+    await user.click(screen.getByTestId("MenuIcon"));
 
-    expect(getByRole("menuitem", { name: "Pick again" })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: "Movies" })).toBeInTheDocument();
-    expect(getByRole("menuitem", { name: "Watched" })).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /Saturday/ })
+      screen.getByRole("menuitem", { name: "Pick again" })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /Family/ })
+      screen.getByRole("menuitem", { name: "Movies" })
     ).toBeInTheDocument();
     expect(
-      await findByRole("menuitem", { name: /New List/ })
+      screen.getByRole("menuitem", { name: "Watched" })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /Saturday/ })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /Family/ })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /New List/ })
     ).toBeInTheDocument();
   });
 
   it("should render the default 'create' nav options", async ({ user }) => {
-    const { getByTestId, findByTestId, getByRole } = renderWithProviders(
-      <NavHamburger />,
-      {
-        route: "/create",
-      }
-    );
+    renderWithProviders(<NavHamburger />, {
+      route: "/create",
+    });
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument();
 
-    await user.click(getByTestId("MenuIcon"));
+    await user.click(screen.getByTestId("MenuIcon"));
 
-    expect(getByRole("menuitem", { name: "Movies" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Movies" })
+    ).toBeInTheDocument();
   });
 
   it("should not render the menu on the 'create' screen when there are no lists created yet", async () => {
-    const { queryByTestId } = render(
+    render(
       <AppContext.Provider value={{ list: undefined }}>
         <MemoryRouter initialEntries={["/create"]}>
           <NavHamburger />
@@ -106,25 +105,26 @@ describe("nav-hamburger", () => {
     );
 
     await waitFor(() => {
-      expect(queryByTestId("MenuIcon")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("MenuIcon")).not.toBeInTheDocument();
     });
   });
 
   it("should close when clicking outside", async ({ user }) => {
-    const { getByTestId, findByTestId, getByRole, queryByRole } =
-      renderWithProviders(<NavHamburger />);
+    renderWithProviders(<NavHamburger />);
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument();
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument();
 
-    await user.click(getByTestId("MenuIcon"));
+    await user.click(screen.getByTestId("MenuIcon"));
 
-    expect(getByRole("menuitem", { name: "Watched" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Watched" })
+    ).toBeInTheDocument();
 
     await user.click(document.body);
 
     await waitFor(() =>
       expect(
-        queryByRole("menuitem", { name: "Watched" })
+        screen.queryByRole("menuitem", { name: "Watched" })
       ).not.toBeInTheDocument()
     );
   });

--- a/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
@@ -1,13 +1,8 @@
 import { waitFor, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import ProfileMenu from "./profile-menu";
-import userEvent from "@testing-library/user-event";
 
 describe("profile-menu", () => {
-  beforeEach((context) => {
-    context.user = userEvent.setup();
-  });
-
   it("should render the menu button with the user image when closed", async () => {
     renderWithProviders(<ProfileMenu />);
     expect(screen.getByAltText("Test User")).toBeInTheDocument();

--- a/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
@@ -3,7 +3,7 @@ import { renderWithProviders } from "../../../../../../utils/render-with-provide
 import ProfileMenu from "./profile-menu";
 
 describe("profile-menu", () => {
-  it("should render the menu button with the user image when closed", async () => {
+  it("should render the menu button with the user image when closed", () => {
     renderWithProviders(<ProfileMenu />);
     expect(screen.getByAltText("Test User")).toBeInTheDocument();
   });

--- a/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
@@ -4,13 +4,13 @@ import ProfileMenu from "./profile-menu";
 
 describe("profile-menu", () => {
   it("should render the menu button with the user image when closed", async () => {
-    const { getByAltText } = await renderWithProviders(<ProfileMenu />);
+    const { getByAltText } = renderWithProviders(<ProfileMenu />);
     expect(getByAltText("Test User")).toBeInTheDocument();
   });
 
   it("should render the profile menu when opened", async () => {
     const { getByAltText, queryAllByAltText, getByText, getByRole } =
-      await renderWithProviders(<ProfileMenu />);
+      renderWithProviders(<ProfileMenu />);
     expect(queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
     fireEvent.click(getByAltText("Test User"));
     expect(queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
@@ -20,8 +20,9 @@ describe("profile-menu", () => {
   });
 
   it("should logout when clicked", async () => {
-    const { getByAltText, getByRole, queryAllByAltText } =
-      await renderWithProviders(<ProfileMenu />);
+    const { getByAltText, getByRole, queryAllByAltText } = renderWithProviders(
+      <ProfileMenu />
+    );
     fireEvent.click(getByAltText("Test User"));
     fireEvent.click(getByRole("button", { name: "Logout" }));
     await waitFor(() => expect(queryAllByAltText("Test User")).toHaveLength(1)); // Main button avatar only
@@ -29,7 +30,7 @@ describe("profile-menu", () => {
 
   it("should close when clicking outside", async () => {
     const { getByAltText, queryByRole, queryAllByAltText } =
-      await renderWithProviders(<ProfileMenu />);
+      renderWithProviders(<ProfileMenu />);
 
     fireEvent.click(getByAltText("Test User"));
 

--- a/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
@@ -1,4 +1,4 @@
-import { waitFor } from "@testing-library/react";
+import { waitFor, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import ProfileMenu from "./profile-menu";
 import userEvent from "@testing-library/user-event";
@@ -9,43 +9,43 @@ describe("profile-menu", () => {
   });
 
   it("should render the menu button with the user image when closed", async () => {
-    const { getByAltText } = renderWithProviders(<ProfileMenu />);
-    expect(getByAltText("Test User")).toBeInTheDocument();
+    renderWithProviders(<ProfileMenu />);
+    expect(screen.getByAltText("Test User")).toBeInTheDocument();
   });
 
   it("should render the profile menu when opened", async ({ user }) => {
-    const { getByAltText, queryAllByAltText, getByText, getByRole } =
-      renderWithProviders(<ProfileMenu />);
-    expect(queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
-    await user.click(getByAltText("Test User"));
-    expect(queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
-    expect(getByText("Test User")).toBeInTheDocument();
-    expect(getByText("test@gmail.com")).toBeInTheDocument();
-    expect(getByRole("button", { name: "Logout" })).toBeInTheDocument();
+    renderWithProviders(<ProfileMenu />);
+    expect(screen.queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
+    await user.click(screen.getByAltText("Test User"));
+    expect(screen.queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+    expect(screen.getByText("test@gmail.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
   });
 
   it("should logout when clicked", async ({ user }) => {
-    const { getByAltText, getByRole, queryAllByAltText } = renderWithProviders(
-      <ProfileMenu />
-    );
-    await user.click(getByAltText("Test User"));
-    await user.click(getByRole("button", { name: "Logout" }));
-    await waitFor(() => expect(queryAllByAltText("Test User")).toHaveLength(1)); // Main button avatar only
+    renderWithProviders(<ProfileMenu />);
+    await user.click(screen.getByAltText("Test User"));
+    await user.click(screen.getByRole("button", { name: "Logout" }));
+    await waitFor(() =>
+      expect(screen.queryAllByAltText("Test User")).toHaveLength(1)
+    ); // Main button avatar only
   });
 
   it("should close when clicking outside", async ({ user }) => {
-    const { getByAltText, queryByRole, queryAllByAltText } =
-      renderWithProviders(<ProfileMenu />);
+    renderWithProviders(<ProfileMenu />);
 
-    await user.click(getByAltText("Test User"));
+    await user.click(screen.getByAltText("Test User"));
 
-    expect(queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
+    expect(screen.queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
 
     await user.click(document.body);
 
     await waitFor(() => {
-      expect(queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
-      expect(queryByRole("button", { name: "Logout" })).not.toBeInTheDocument();
+      expect(screen.queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
+      expect(
+        screen.queryByRole("button", { name: "Logout" })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.test.jsx
@@ -1,52 +1,50 @@
-import { fireEvent, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 import ProfileMenu from "./profile-menu";
+import userEvent from "@testing-library/user-event";
 
 describe("profile-menu", () => {
+  beforeEach((context) => {
+    context.user = userEvent.setup();
+  });
+
   it("should render the menu button with the user image when closed", async () => {
     const { getByAltText } = renderWithProviders(<ProfileMenu />);
     expect(getByAltText("Test User")).toBeInTheDocument();
   });
 
-  it("should render the profile menu when opened", async () => {
+  it("should render the profile menu when opened", async ({ user }) => {
     const { getByAltText, queryAllByAltText, getByText, getByRole } =
       renderWithProviders(<ProfileMenu />);
     expect(queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
-    fireEvent.click(getByAltText("Test User"));
+    await user.click(getByAltText("Test User"));
     expect(queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
     expect(getByText("Test User")).toBeInTheDocument();
     expect(getByText("test@gmail.com")).toBeInTheDocument();
     expect(getByRole("button", { name: "Logout" })).toBeInTheDocument();
   });
 
-  it("should logout when clicked", async () => {
+  it("should logout when clicked", async ({ user }) => {
     const { getByAltText, getByRole, queryAllByAltText } = renderWithProviders(
       <ProfileMenu />
     );
-    fireEvent.click(getByAltText("Test User"));
-    fireEvent.click(getByRole("button", { name: "Logout" }));
+    await user.click(getByAltText("Test User"));
+    await user.click(getByRole("button", { name: "Logout" }));
     await waitFor(() => expect(queryAllByAltText("Test User")).toHaveLength(1)); // Main button avatar only
   });
 
-  it("should close when clicking outside", async () => {
+  it("should close when clicking outside", async ({ user }) => {
     const { getByAltText, queryByRole, queryAllByAltText } =
       renderWithProviders(<ProfileMenu />);
 
-    fireEvent.click(getByAltText("Test User"));
+    await user.click(getByAltText("Test User"));
 
     expect(queryAllByAltText("Test User")).toHaveLength(2); // Once opened, the larger avatar is in the menu as well
 
-    // Couldn't figure out a better way to make this work.
-    // There's some discussion here but seems the click away listener is not "armed" immediately due to a react bug.
-    // I've needed to use a wait here to make sure the click away is ready.
-    // https://github.com/mui/material-ui/issues/24783#issuecomment-774054038
-    await waitFor(() => new Promise((r) => setTimeout(r, 1)));
-
-    fireEvent.click(document);
+    await user.click(document.body);
 
     await waitFor(() => {
       expect(queryAllByAltText("Test User")).toHaveLength(1); // Main button avatar
-
       expect(queryByRole("button", { name: "Logout" })).not.toBeInTheDocument();
     });
   });

--- a/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
@@ -1,6 +1,6 @@
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import TitleBar from "./titlebar";
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { AppContext } from "../../../../context/app-context";
 import { createMatchMedia } from "../../../../utils/create-match-media";
 import { vi } from "vitest";
@@ -31,7 +31,9 @@ describe("titlebar", () => {
     expect(await screen.findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
   });
 
-  it("should render the titlebar for the pick screen on mobile", async () => {
+  it("should render the titlebar for the pick screen on mobile", async ({
+    user,
+  }) => {
     // Mock a 500 pixel width
     window.matchMedia = createMatchMedia(500);
 
@@ -53,7 +55,7 @@ describe("titlebar", () => {
       await screen.findByRole("button", { name: "Pick Again" })
     ).toBeInTheDocument(); // Find the Pick Again button
 
-    fireEvent.click(screen.getByRole("button", { name: "Pick Again" }));
+    await user.click(screen.getByRole("button", { name: "Pick Again" }));
 
     expect(clearPick).toHaveBeenCalled();
   });

--- a/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
@@ -7,8 +7,9 @@ import { vi } from "vitest";
 
 describe("titlebar", () => {
   it("should render the titlebar for the home screen", async () => {
-    const { getByLabelText, getByAltText, getByRole } =
-      await renderWithProviders(<TitleBar />);
+    const { getByLabelText, getByAltText, getByRole } = renderWithProviders(
+      <TitleBar />
+    );
 
     await waitFor(() => {
       expect(getByRole("button", { name: "Watched" })).toBeInTheDocument(); // Find the Nav
@@ -21,8 +22,9 @@ describe("titlebar", () => {
     // Mock a 500 pixel width
     window.matchMedia = createMatchMedia(500);
 
-    const { getByLabelText, getByAltText, getByTestId } =
-      await renderWithProviders(<TitleBar />);
+    const { getByLabelText, getByAltText, getByTestId } = renderWithProviders(
+      <TitleBar />
+    );
 
     await waitFor(() => {
       expect(getByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
@@ -38,7 +40,7 @@ describe("titlebar", () => {
     const clearPick = vi.fn();
 
     const { getByLabelText, getByAltText, getByTestId, getByRole } =
-      await renderWithProviders(
+      renderWithProviders(
         <AppContext.Provider value={{ movies: [], clearPick }}>
           <TitleBar />
         </AppContext.Provider>,

--- a/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
@@ -1,31 +1,34 @@
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import TitleBar from "./titlebar";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { AppContext } from "../../../../context/app-context";
 import { createMatchMedia } from "../../../../utils/create-match-media";
 import { vi } from "vitest";
 
 describe("titlebar", () => {
   it("should render the titlebar for the home screen", async () => {
-    const { findByLabelText, findByAltText, findByRole } = renderWithProviders(
-      <TitleBar />
-    );
+    renderWithProviders(<TitleBar />);
 
-    expect(await findByRole("button", { name: "Watched" })).toBeInTheDocument(); // Find the Nav
-    expect(await findByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
-    expect(await findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
+    expect(
+      await screen.findByRole("button", { name: "Watched" })
+    ).toBeInTheDocument(); // Find the Nav
+    expect(
+      await screen.findByLabelText("Movie Decider 4000")
+    ).toBeInTheDocument(); // Find the Logo
+    expect(await screen.findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
   });
 
   it("should render the titlebar for mobile", async () => {
     // Mock a 500 pixel width
     window.matchMedia = createMatchMedia(500);
 
-    const { findByLabelText, findByAltText, findByTestId } =
-      renderWithProviders(<TitleBar />);
+    renderWithProviders(<TitleBar />);
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
-    expect(await findByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
-    expect(await findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
+    expect(
+      await screen.findByLabelText("Movie Decider 4000")
+    ).toBeInTheDocument(); // Find the Logo
+    expect(await screen.findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
   });
 
   it("should render the titlebar for the pick screen on mobile", async () => {
@@ -34,27 +37,23 @@ describe("titlebar", () => {
 
     const clearPick = vi.fn();
 
-    const {
-      findByLabelText,
-      findByAltText,
-      findByTestId,
-      findByRole,
-      getByRole,
-    } = renderWithProviders(
+    renderWithProviders(
       <AppContext.Provider value={{ movies: [], clearPick }}>
         <TitleBar />
       </AppContext.Provider>,
       { route: "/pick" }
     );
 
-    expect(await findByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
-    expect(await findByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
-    expect(await findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
+    expect(await screen.findByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
     expect(
-      await findByRole("button", { name: "Pick Again" })
+      await screen.findByLabelText("Movie Decider 4000")
+    ).toBeInTheDocument(); // Find the Logo
+    expect(await screen.findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
+    expect(
+      await screen.findByRole("button", { name: "Pick Again" })
     ).toBeInTheDocument(); // Find the Pick Again button
 
-    fireEvent.click(getByRole("button", { name: "Pick Again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Pick Again" }));
 
     expect(clearPick).toHaveBeenCalled();
   });

--- a/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
+++ b/packages/web/src/components/app/components/titlebar/titlebar.test.jsx
@@ -1,36 +1,31 @@
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import TitleBar from "./titlebar";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 import { AppContext } from "../../../../context/app-context";
 import { createMatchMedia } from "../../../../utils/create-match-media";
 import { vi } from "vitest";
 
 describe("titlebar", () => {
   it("should render the titlebar for the home screen", async () => {
-    const { getByLabelText, getByAltText, getByRole } = renderWithProviders(
+    const { findByLabelText, findByAltText, findByRole } = renderWithProviders(
       <TitleBar />
     );
 
-    await waitFor(() => {
-      expect(getByRole("button", { name: "Watched" })).toBeInTheDocument(); // Find the Nav
-      expect(getByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
-      expect(getByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
-    });
+    expect(await findByRole("button", { name: "Watched" })).toBeInTheDocument(); // Find the Nav
+    expect(await findByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
+    expect(await findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
   });
 
   it("should render the titlebar for mobile", async () => {
     // Mock a 500 pixel width
     window.matchMedia = createMatchMedia(500);
 
-    const { getByLabelText, getByAltText, getByTestId } = renderWithProviders(
-      <TitleBar />
-    );
+    const { findByLabelText, findByAltText, findByTestId } =
+      renderWithProviders(<TitleBar />);
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
-      expect(getByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
-      expect(getByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
-    });
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
+    expect(await findByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
+    expect(await findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
   });
 
   it("should render the titlebar for the pick screen on mobile", async () => {
@@ -39,20 +34,25 @@ describe("titlebar", () => {
 
     const clearPick = vi.fn();
 
-    const { getByLabelText, getByAltText, getByTestId, getByRole } =
-      renderWithProviders(
-        <AppContext.Provider value={{ movies: [], clearPick }}>
-          <TitleBar />
-        </AppContext.Provider>,
-        { route: "/pick" }
-      );
+    const {
+      findByLabelText,
+      findByAltText,
+      findByTestId,
+      findByRole,
+      getByRole,
+    } = renderWithProviders(
+      <AppContext.Provider value={{ movies: [], clearPick }}>
+        <TitleBar />
+      </AppContext.Provider>,
+      { route: "/pick" }
+    );
 
-    await waitFor(() => {
-      expect(getByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
-      expect(getByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
-      expect(getByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
-      expect(getByRole("button", { name: "Pick Again" })).toBeInTheDocument(); // Find the Pick Again button
-    });
+    expect(await findByTestId("MenuIcon")).toBeInTheDocument(); // Find the Nav
+    expect(await findByLabelText("Movie Decider 4000")).toBeInTheDocument(); // Find the Logo
+    expect(await findByAltText("Test User")).toBeInTheDocument(); // Find the Profile Menu
+    expect(
+      await findByRole("button", { name: "Pick Again" })
+    ).toBeInTheDocument(); // Find the Pick Again button
 
     fireEvent.click(getByRole("button", { name: "Pick Again" }));
 

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
@@ -14,7 +14,7 @@ describe("date-picker", () => {
     };
   });
 
-  it("should render the date picker without a drawer by default", async ({
+  it("should render the date picker without a drawer by default", ({
     props,
   }) => {
     renderWithProviders(<DatePicker {...props} />);
@@ -23,7 +23,7 @@ describe("date-picker", () => {
     expect(screen.getByTestId("datePicker")).toBeInTheDocument();
   });
 
-  it("should render the date picker in a drawer when useDrawer is true", async ({
+  it("should render the date picker in a drawer when useDrawer is true", ({
     props,
   }) => {
     renderWithProviders(<DatePicker {...props} useDrawer />);
@@ -32,19 +32,19 @@ describe("date-picker", () => {
     expect(screen.getByTestId("datePicker")).toBeInTheDocument();
   });
 
-  it("should ignore title when not in a drawer", async ({ props }) => {
+  it("should ignore title when not in a drawer", ({ props }) => {
     renderWithProviders(<DatePicker {...props} title="Test Title" />);
 
     expect(screen.queryByText("Test Title")).not.toBeInTheDocument();
   });
 
-  it("should render the title when in a drawer", async ({ props }) => {
+  it("should render the title when in a drawer", ({ props }) => {
     renderWithProviders(<DatePicker {...props} useDrawer title="Test Title" />);
 
     expect(screen.queryByText("Test Title")).toBeInTheDocument();
   });
 
-  it("should set the default date", async ({ props }) => {
+  it("should set the default date", ({ props }) => {
     renderWithProviders(<DatePicker {...props} />);
     expect(screen.getByText("January 2022")).toBeInTheDocument();
     expect(

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import DatePicker from "./date-picker";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
@@ -17,89 +17,81 @@ describe("date-picker", () => {
   it("should render the date picker without a drawer by default", async ({
     props,
   }) => {
-    const { getByTestId, queryByRole } = renderWithProviders(
-      <DatePicker {...props} />
-    );
+    renderWithProviders(<DatePicker {...props} />);
 
-    expect(queryByRole("presentation")).not.toBeInTheDocument();
-    expect(getByTestId("datePicker")).toBeInTheDocument();
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+    expect(screen.getByTestId("datePicker")).toBeInTheDocument();
   });
 
   it("should render the date picker in a drawer when useDrawer is true", async ({
     props,
   }) => {
-    const { getByTestId, queryByRole } = renderWithProviders(
-      <DatePicker {...props} useDrawer />
-    );
+    renderWithProviders(<DatePicker {...props} useDrawer />);
 
-    expect(queryByRole("presentation")).toBeInTheDocument();
-    expect(getByTestId("datePicker")).toBeInTheDocument();
+    expect(screen.queryByRole("presentation")).toBeInTheDocument();
+    expect(screen.getByTestId("datePicker")).toBeInTheDocument();
   });
 
   it("should ignore title when not in a drawer", async ({ props }) => {
-    const { queryByText } = renderWithProviders(
-      <DatePicker {...props} title="Test Title" />
-    );
+    renderWithProviders(<DatePicker {...props} title="Test Title" />);
 
-    expect(queryByText("Test Title")).not.toBeInTheDocument();
+    expect(screen.queryByText("Test Title")).not.toBeInTheDocument();
   });
 
   it("should render the title when in a drawer", async ({ props }) => {
-    const { queryByText } = renderWithProviders(
-      <DatePicker {...props} useDrawer title="Test Title" />
-    );
+    renderWithProviders(<DatePicker {...props} useDrawer title="Test Title" />);
 
-    expect(queryByText("Test Title")).toBeInTheDocument();
+    expect(screen.queryByText("Test Title")).toBeInTheDocument();
   });
 
   it("should set the default date", async ({ props }) => {
-    const { getByText, getByRole } = renderWithProviders(
-      <DatePicker {...props} />
-    );
-    expect(getByText("January 2022")).toBeInTheDocument();
-    expect(getByRole("button", { name: "2nd January (Sunday)" })).toHaveClass(
-      "rdp-day_selected"
-    );
+    renderWithProviders(<DatePicker {...props} />);
+    expect(screen.getByText("January 2022")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "2nd January (Sunday)" })
+    ).toHaveClass("rdp-day_selected");
   });
 
   it("should call onChange when changing the date", async ({ props }) => {
-    const { getByRole } = renderWithProviders(<DatePicker {...props} />);
+    renderWithProviders(<DatePicker {...props} />);
 
-    expect(getByRole("button", { name: "2nd January (Sunday)" })).toHaveClass(
-      "rdp-day_selected"
+    expect(
+      screen.getByRole("button", { name: "2nd January (Sunday)" })
+    ).toHaveClass("rdp-day_selected");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "1st January (Saturday)" })
     );
-
-    fireEvent.click(getByRole("button", { name: "1st January (Saturday)" }));
 
     expect(props.onChange).toHaveBeenCalled();
 
     expect(
-      getByRole("button", { name: "2nd January (Sunday)" })
+      screen.getByRole("button", { name: "2nd January (Sunday)" })
     ).not.toHaveClass("rdp-day_selected");
 
-    expect(getByRole("button", { name: "1st January (Saturday)" })).toHaveClass(
-      "rdp-day_selected"
-    );
+    expect(
+      screen.getByRole("button", { name: "1st January (Saturday)" })
+    ).toHaveClass("rdp-day_selected");
   });
 
   it("should call onDelete", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
-    expect(getByTestId("DeleteIcon")).toBeInTheDocument();
-    fireEvent.click(getByTestId("DeleteIcon"));
+    renderWithProviders(<DatePicker {...props} />);
+    expect(screen.getByTestId("DeleteIcon")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("DeleteIcon"));
     expect(props.onDelete).toHaveBeenCalled();
   });
 
   it("should call onCancel", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
-    expect(getByTestId("CloseIcon")).toBeInTheDocument();
-    fireEvent.click(getByTestId("CloseIcon"));
+    renderWithProviders(<DatePicker {...props} />);
+    expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("CloseIcon"));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
   it("should call onSave", async ({ props }) => {
-    const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
-    expect(getByTestId("CalendarCheckIcon")).toBeInTheDocument();
-    fireEvent.click(getByTestId("CalendarCheckIcon"));
+    renderWithProviders(<DatePicker {...props} />);
+    expect(screen.getByTestId("CalendarCheckIcon")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("CalendarCheckIcon"));
     expect(props.onSave).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
@@ -4,10 +4,8 @@ import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
 
 describe("date-picker", () => {
-  let props;
-
-  beforeEach(() => {
-    props = {
+  beforeEach((context) => {
+    context.props = {
       defaultDate: new Date("2022-01-02T12:00:00"),
       onChange: vi.fn(),
       onCancel: vi.fn(),
@@ -16,7 +14,9 @@ describe("date-picker", () => {
     };
   });
 
-  it("should render the date picker without a drawer by default", async () => {
+  it("should render the date picker without a drawer by default", async ({
+    props,
+  }) => {
     const { getByTestId, queryByRole } = renderWithProviders(
       <DatePicker {...props} />
     );
@@ -25,7 +25,9 @@ describe("date-picker", () => {
     expect(getByTestId("datePicker")).toBeInTheDocument();
   });
 
-  it("should render the date picker in a drawer when useDrawer is true", async () => {
+  it("should render the date picker in a drawer when useDrawer is true", async ({
+    props,
+  }) => {
     const { getByTestId, queryByRole } = renderWithProviders(
       <DatePicker {...props} useDrawer />
     );
@@ -34,7 +36,7 @@ describe("date-picker", () => {
     expect(getByTestId("datePicker")).toBeInTheDocument();
   });
 
-  it("should ignore title when not in a drawer", async () => {
+  it("should ignore title when not in a drawer", async ({ props }) => {
     const { queryByText } = renderWithProviders(
       <DatePicker {...props} title="Test Title" />
     );
@@ -42,7 +44,7 @@ describe("date-picker", () => {
     expect(queryByText("Test Title")).not.toBeInTheDocument();
   });
 
-  it("should render the title when in a drawer", async () => {
+  it("should render the title when in a drawer", async ({ props }) => {
     const { queryByText } = renderWithProviders(
       <DatePicker {...props} useDrawer title="Test Title" />
     );
@@ -50,7 +52,7 @@ describe("date-picker", () => {
     expect(queryByText("Test Title")).toBeInTheDocument();
   });
 
-  it("should set the default date", async () => {
+  it("should set the default date", async ({ props }) => {
     const { getByText, getByRole } = renderWithProviders(
       <DatePicker {...props} />
     );
@@ -60,7 +62,7 @@ describe("date-picker", () => {
     );
   });
 
-  it("should call onChange when changing the date", async () => {
+  it("should call onChange when changing the date", async ({ props }) => {
     const { getByRole } = renderWithProviders(<DatePicker {...props} />);
 
     expect(getByRole("button", { name: "2nd January (Sunday)" })).toHaveClass(
@@ -80,21 +82,21 @@ describe("date-picker", () => {
     );
   });
 
-  it("should call onDelete", async () => {
+  it("should call onDelete", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
     expect(getByTestId("DeleteIcon")).toBeInTheDocument();
     fireEvent.click(getByTestId("DeleteIcon"));
     expect(props.onDelete).toHaveBeenCalled();
   });
 
-  it("should call onCancel", async () => {
+  it("should call onCancel", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
     expect(getByTestId("CloseIcon")).toBeInTheDocument();
     fireEvent.click(getByTestId("CloseIcon"));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
-  it("should call onSave", async () => {
+  it("should call onSave", async ({ props }) => {
     const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
     expect(getByTestId("CalendarCheckIcon")).toBeInTheDocument();
     fireEvent.click(getByTestId("CalendarCheckIcon"));

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
@@ -17,7 +17,7 @@ describe("date-picker", () => {
   });
 
   it("should render the date picker without a drawer by default", async () => {
-    const { getByTestId, queryByRole } = await renderWithProviders(
+    const { getByTestId, queryByRole } = renderWithProviders(
       <DatePicker {...props} />
     );
 
@@ -26,7 +26,7 @@ describe("date-picker", () => {
   });
 
   it("should render the date picker in a drawer when useDrawer is true", async () => {
-    const { getByTestId, queryByRole } = await renderWithProviders(
+    const { getByTestId, queryByRole } = renderWithProviders(
       <DatePicker {...props} useDrawer />
     );
 
@@ -35,7 +35,7 @@ describe("date-picker", () => {
   });
 
   it("should ignore title when not in a drawer", async () => {
-    const { queryByText } = await renderWithProviders(
+    const { queryByText } = renderWithProviders(
       <DatePicker {...props} title="Test Title" />
     );
 
@@ -43,7 +43,7 @@ describe("date-picker", () => {
   });
 
   it("should render the title when in a drawer", async () => {
-    const { queryByText } = await renderWithProviders(
+    const { queryByText } = renderWithProviders(
       <DatePicker {...props} useDrawer title="Test Title" />
     );
 
@@ -51,7 +51,7 @@ describe("date-picker", () => {
   });
 
   it("should set the default date", async () => {
-    const { getByText, getByRole } = await renderWithProviders(
+    const { getByText, getByRole } = renderWithProviders(
       <DatePicker {...props} />
     );
     expect(getByText("January 2022")).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe("date-picker", () => {
   });
 
   it("should call onChange when changing the date", async () => {
-    const { getByRole } = await renderWithProviders(<DatePicker {...props} />);
+    const { getByRole } = renderWithProviders(<DatePicker {...props} />);
 
     expect(getByRole("button", { name: "2nd January (Sunday)" })).toHaveClass(
       "rdp-day_selected"
@@ -81,27 +81,21 @@ describe("date-picker", () => {
   });
 
   it("should call onDelete", async () => {
-    const { getByTestId } = await renderWithProviders(
-      <DatePicker {...props} />
-    );
+    const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
     expect(getByTestId("DeleteIcon")).toBeInTheDocument();
     fireEvent.click(getByTestId("DeleteIcon"));
     expect(props.onDelete).toHaveBeenCalled();
   });
 
   it("should call onCancel", async () => {
-    const { getByTestId } = await renderWithProviders(
-      <DatePicker {...props} />
-    );
+    const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
     expect(getByTestId("CloseIcon")).toBeInTheDocument();
     fireEvent.click(getByTestId("CloseIcon"));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
   it("should call onSave", async () => {
-    const { getByTestId } = await renderWithProviders(
-      <DatePicker {...props} />
-    );
+    const { getByTestId } = renderWithProviders(<DatePicker {...props} />);
     expect(getByTestId("CalendarCheckIcon")).toBeInTheDocument();
     fireEvent.click(getByTestId("CalendarCheckIcon"));
     expect(props.onSave).toHaveBeenCalled();

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import DatePicker from "./date-picker";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../utils/render-with-providers";
@@ -52,14 +52,14 @@ describe("date-picker", () => {
     ).toHaveClass("rdp-day_selected");
   });
 
-  it("should call onChange when changing the date", async ({ props }) => {
+  it("should call onChange when changing the date", async ({ props, user }) => {
     renderWithProviders(<DatePicker {...props} />);
 
     expect(
       screen.getByRole("button", { name: "2nd January (Sunday)" })
     ).toHaveClass("rdp-day_selected");
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", { name: "1st January (Saturday)" })
     );
 
@@ -74,24 +74,24 @@ describe("date-picker", () => {
     ).toHaveClass("rdp-day_selected");
   });
 
-  it("should call onDelete", async ({ props }) => {
+  it("should call onDelete", async ({ props, user }) => {
     renderWithProviders(<DatePicker {...props} />);
     expect(screen.getByTestId("DeleteIcon")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("DeleteIcon"));
+    await user.click(screen.getByTestId("DeleteIcon"));
     expect(props.onDelete).toHaveBeenCalled();
   });
 
-  it("should call onCancel", async ({ props }) => {
+  it("should call onCancel", async ({ props, user }) => {
     renderWithProviders(<DatePicker {...props} />);
     expect(screen.getByTestId("CloseIcon")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("CloseIcon"));
+    await user.click(screen.getByTestId("CloseIcon"));
     expect(props.onCancel).toHaveBeenCalled();
   });
 
-  it("should call onSave", async ({ props }) => {
+  it("should call onSave", async ({ props, user }) => {
     renderWithProviders(<DatePicker {...props} />);
     expect(screen.getByTestId("CalendarCheckIcon")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("CalendarCheckIcon"));
+    await user.click(screen.getByTestId("CalendarCheckIcon"));
     expect(props.onSave).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
@@ -3,7 +3,7 @@ import { buildMovieMock } from "../../../../../../utils/build-movie-mock";
 import WatchedMovie from "./watched-movie";
 import { vi } from "vitest";
 import { buildThirdPartyMovieMock } from "../../../../../../utils/build-third-party-movie-mock";
-import { fireEvent, within } from "@testing-library/dom";
+import { fireEvent, within, screen } from "@testing-library/react";
 import * as mui from "@mui/material";
 import { Globals } from "@react-spring/web";
 import { GET_THIRD_PARTY_MOVIE_FULL_DETAILS } from "../../../../../../graphql/queries";
@@ -49,33 +49,32 @@ describe("watched-movie", () => {
   afterEach(() => vi.clearAllMocks());
 
   it("should render the title, date and poster", async ({ props }) => {
-    const { getByLabelText, getByTestId } = renderWithProviders(
-      <WatchedMovie {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     expect(
-      within(getByTestId("info")).getByText("Test Movie")
+      within(screen.getByTestId("info")).getByText("Test Movie")
     ).toBeInTheDocument();
 
     expect(
-      within(getByTestId("info")).getByText("Saturday, September 4th, 2021")
+      within(screen.getByTestId("info")).getByText(
+        "Saturday, September 4th, 2021"
+      )
     ).toBeInTheDocument();
 
-    expect(getByLabelText("Test Movie Poster")).toBeInTheDocument();
+    expect(screen.getByLabelText("Test Movie Poster")).toBeInTheDocument();
   });
 
   it("should render the poster followed by the info when left-aligned", async ({
     props,
   }) => {
-    const { getByTestId } = renderWithProviders(<WatchedMovie {...props} />, {
+    renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
     // Test the order. When left-aligned, the poster should come before the info
-    const [posterNode, infoNode] = getByTestId("content").childNodes;
+    const [posterNode, infoNode] = screen.getByTestId("content").childNodes;
     expect(posterNode.compareDocumentPosition(infoNode)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
@@ -84,15 +83,12 @@ describe("watched-movie", () => {
   it("should render the info followed by the poster when right-aligned", async ({
     props,
   }) => {
-    const { getByTestId } = renderWithProviders(
-      <WatchedMovie {...props} right />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<WatchedMovie {...props} right />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     // Test the order. When right-aligned, the info should come before the poster
-    const [infoNode, posterNode] = getByTestId("content").childNodes;
+    const [infoNode, posterNode] = screen.getByTestId("content").childNodes;
     expect(posterNode.compareDocumentPosition(infoNode)).toBe(
       Node.DOCUMENT_POSITION_PRECEDING
     );
@@ -107,12 +103,12 @@ describe("watched-movie", () => {
       .fn()
       .mockImplementation((query) => query === "(max-width: 550px)");
 
-    const { getByTestId } = renderWithProviders(<WatchedMovie {...props} />, {
+    renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
     expect(
-      within(getByTestId("info")).getByText("Saturday, Sep 4th, 2021")
+      within(screen.getByTestId("info")).getByText("Saturday, Sep 4th, 2021")
     ).toBeInTheDocument();
   });
 
@@ -125,30 +121,27 @@ describe("watched-movie", () => {
       .fn()
       .mockImplementation((query) => query === "(max-width: 430px)");
 
-    const { getByTestId } = renderWithProviders(<WatchedMovie {...props} />, {
+    renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
     expect(
-      within(getByTestId("info")).getByText("Sat, Sep 4th, 2021")
+      within(screen.getByTestId("info")).getByText("Sat, Sep 4th, 2021")
     ).toBeInTheDocument();
   });
 
   it("should show the date picker inline at larger sizes", async ({
     props,
   }) => {
-    const { getByLabelText, findByTestId, queryByRole } = renderWithProviders(
-      <WatchedMovie {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByLabelText("Test Movie"));
+    fireEvent.click(screen.getByLabelText("Test Movie"));
 
-    expect(await findByTestId("datePicker")).toBeInTheDocument();
+    expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    expect(queryByRole("presentation")).not.toBeInTheDocument();
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
   });
 
   it("should show the date picker in a drawer at small size", async ({
@@ -160,35 +153,31 @@ describe("watched-movie", () => {
       .fn()
       .mockImplementation((query) => query === "(max-width: 550px)");
 
-    const { getByLabelText, getByRole, findByRole } = renderWithProviders(
-      <WatchedMovie {...props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByLabelText("Test Movie"));
+    fireEvent.click(screen.getByLabelText("Test Movie"));
 
-    expect(await findByRole("presentation")).toBeInTheDocument();
+    expect(await screen.findByRole("presentation")).toBeInTheDocument();
 
     expect(
-      within(getByRole("presentation")).getByTestId("datePicker")
+      within(screen.getByRole("presentation")).getByTestId("datePicker")
     ).toBeInTheDocument();
   });
 
   it("should call onSave with the new date", async ({ props }) => {
-    const { getByLabelText, getByRole, getByTestId, findByTestId } =
-      renderWithProviders(<WatchedMovie {...props} />, {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByLabelText("Test Movie"));
+    fireEvent.click(screen.getByLabelText("Test Movie"));
 
-    expect(await findByTestId("datePicker")).toBeInTheDocument();
+    expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    fireEvent.click(getByRole("button", { name: /10th/ }));
+    fireEvent.click(screen.getByRole("button", { name: /10th/ }));
 
-    fireEvent.click(getByTestId("CalendarCheckIcon"));
+    fireEvent.click(screen.getByTestId("CalendarCheckIcon"));
 
     expect(props.onSave).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -200,18 +189,17 @@ describe("watched-movie", () => {
   it("should call onCancel when clicking the cancel button on the date picker", async ({
     props,
   }) => {
-    const { getByLabelText, getByRole, getByTestId, findByTestId } =
-      renderWithProviders(<WatchedMovie {...props} />, {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByLabelText("Test Movie"));
+    fireEvent.click(screen.getByLabelText("Test Movie"));
 
-    expect(await findByTestId("datePicker")).toBeInTheDocument();
+    expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    fireEvent.click(getByRole("button", { name: /10th/ }));
+    fireEvent.click(screen.getByRole("button", { name: /10th/ }));
 
-    fireEvent.click(getByTestId("CloseIcon"));
+    fireEvent.click(screen.getByTestId("CloseIcon"));
 
     expect(props.onCancel).toHaveBeenCalled();
 
@@ -219,31 +207,27 @@ describe("watched-movie", () => {
   });
 
   it("should call onCancel when clicking the backdrop", async ({ props }) => {
-    const { getByLabelText } = renderWithProviders(
-      <WatchedMovie {...props} isEditing />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    renderWithProviders(<WatchedMovie {...props} isEditing />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByLabelText("Test Movie"));
+    fireEvent.click(screen.getByLabelText("Test Movie"));
 
     expect(props.onCancel).toHaveBeenCalled();
   });
 
   it("should call onDelete with the correct movie data", async ({ props }) => {
-    const { getByLabelText, getByRole, getByTestId, findByTestId } =
-      renderWithProviders(<WatchedMovie {...props} />, {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
-    fireEvent.click(getByLabelText("Test Movie"));
+    fireEvent.click(screen.getByLabelText("Test Movie"));
 
-    expect(await findByTestId("datePicker")).toBeInTheDocument();
+    expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    fireEvent.click(getByRole("button", { name: /10th/ }));
+    fireEvent.click(screen.getByRole("button", { name: /10th/ }));
 
-    fireEvent.click(getByTestId("DeleteIcon"));
+    fireEvent.click(screen.getByTestId("DeleteIcon"));
 
     expect(props.onCancel).toHaveBeenCalled();
     expect(props.onDelete).toHaveBeenCalledWith(props.movie);

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
@@ -48,7 +48,7 @@ describe("watched-movie", () => {
 
   afterEach(() => vi.clearAllMocks());
 
-  it("should render the title, date and poster", async ({ props }) => {
+  it("should render the title, date and poster", ({ props }) => {
     renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
@@ -66,7 +66,7 @@ describe("watched-movie", () => {
     expect(screen.getByLabelText("Test Movie Poster")).toBeInTheDocument();
   });
 
-  it("should render the poster followed by the info when left-aligned", async ({
+  it("should render the poster followed by the info when left-aligned", ({
     props,
   }) => {
     renderWithProviders(<WatchedMovie {...props} />, {
@@ -80,7 +80,7 @@ describe("watched-movie", () => {
     );
   });
 
-  it("should render the info followed by the poster when right-aligned", async ({
+  it("should render the info followed by the poster when right-aligned", ({
     props,
   }) => {
     renderWithProviders(<WatchedMovie {...props} right />, {
@@ -94,7 +94,7 @@ describe("watched-movie", () => {
     );
   });
 
-  it("should render the date correctly when the breakpoint is small", async ({
+  it("should render the date correctly when the breakpoint is small", ({
     props,
   }) => {
     // Mock "small"
@@ -112,7 +112,7 @@ describe("watched-movie", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render the date correctly when the breakpoint is xsmall", async ({
+  it("should render the date correctly when the breakpoint is xsmall", ({
     props,
   }) => {
     // Mock "xsmall"

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
@@ -53,7 +53,7 @@ describe("watched-movie", () => {
   afterEach(() => vi.clearAllMocks());
 
   it("should render the title, date and poster", async () => {
-    const { getByLabelText, getByTestId } = await renderWithProviders(
+    const { getByLabelText, getByTestId } = renderWithProviders(
       <WatchedMovie {...test.props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -72,7 +72,7 @@ describe("watched-movie", () => {
   });
 
   it("should render the poster followed by the info when left-aligned", async () => {
-    const { getByTestId } = await renderWithProviders(
+    const { getByTestId } = renderWithProviders(
       <WatchedMovie {...test.props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -87,7 +87,7 @@ describe("watched-movie", () => {
   });
 
   it("should render the info followed by the poster when right-aligned", async () => {
-    const { getByTestId } = await renderWithProviders(
+    const { getByTestId } = renderWithProviders(
       <WatchedMovie {...test.props} right />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -108,7 +108,7 @@ describe("watched-movie", () => {
       .fn()
       .mockImplementation((query) => query === "(max-width: 550px)");
 
-    const { getByTestId } = await renderWithProviders(
+    const { getByTestId } = renderWithProviders(
       <WatchedMovie {...test.props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -127,7 +127,7 @@ describe("watched-movie", () => {
       .fn()
       .mockImplementation((query) => query === "(max-width: 430px)");
 
-    const { getByTestId } = await renderWithProviders(
+    const { getByTestId } = renderWithProviders(
       <WatchedMovie {...test.props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -140,10 +140,12 @@ describe("watched-movie", () => {
   });
 
   it("should show the date picker inline at larger sizes", async () => {
-    const { getByLabelText, getByTestId, queryByRole } =
-      await renderWithProviders(<WatchedMovie {...test.props} />, {
+    const { getByLabelText, getByTestId, queryByRole } = renderWithProviders(
+      <WatchedMovie {...test.props} />,
+      {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+      }
+    );
 
     fireEvent.click(getByLabelText("Test Movie"));
 
@@ -161,7 +163,7 @@ describe("watched-movie", () => {
       .fn()
       .mockImplementation((query) => query === "(max-width: 550px)");
 
-    const { getByLabelText, getByRole } = await renderWithProviders(
+    const { getByLabelText, getByRole } = renderWithProviders(
       <WatchedMovie {...test.props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -180,10 +182,12 @@ describe("watched-movie", () => {
   });
 
   it("should call onSave with the new date", async () => {
-    const { getByLabelText, getByRole, getByTestId } =
-      await renderWithProviders(<WatchedMovie {...test.props} />, {
+    const { getByLabelText, getByRole, getByTestId } = renderWithProviders(
+      <WatchedMovie {...test.props} />,
+      {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+      }
+    );
 
     fireEvent.click(getByLabelText("Test Movie"));
 
@@ -203,10 +207,12 @@ describe("watched-movie", () => {
   });
 
   it("should call onCancel when clicking the cancel button on the date picker", async () => {
-    const { getByLabelText, getByRole, getByTestId } =
-      await renderWithProviders(<WatchedMovie {...test.props} />, {
+    const { getByLabelText, getByRole, getByTestId } = renderWithProviders(
+      <WatchedMovie {...test.props} />,
+      {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+      }
+    );
 
     fireEvent.click(getByLabelText("Test Movie"));
 
@@ -224,7 +230,7 @@ describe("watched-movie", () => {
   });
 
   it("should call onCancel when clicking the backdrop", async () => {
-    const { getByLabelText } = await renderWithProviders(
+    const { getByLabelText } = renderWithProviders(
       <WatchedMovie {...test.props} isEditing />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
@@ -237,10 +243,12 @@ describe("watched-movie", () => {
   });
 
   it("should call onDelete with the correct movie data", async () => {
-    const { getByLabelText, getByRole, getByTestId } =
-      await renderWithProviders(<WatchedMovie {...test.props} />, {
+    const { getByLabelText, getByRole, getByTestId } = renderWithProviders(
+      <WatchedMovie {...test.props} />,
+      {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      });
+      }
+    );
 
     fireEvent.click(getByLabelText("Test Movie"));
 

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
@@ -3,7 +3,7 @@ import { buildMovieMock } from "../../../../../../utils/build-movie-mock";
 import WatchedMovie from "./watched-movie";
 import { vi } from "vitest";
 import { buildThirdPartyMovieMock } from "../../../../../../utils/build-third-party-movie-mock";
-import { fireEvent, waitFor, within } from "@testing-library/dom";
+import { fireEvent, within } from "@testing-library/dom";
 import * as mui from "@mui/material";
 import { Globals } from "@react-spring/web";
 import { GET_THIRD_PARTY_MOVIE_FULL_DETAILS } from "../../../../../../graphql/queries";
@@ -28,33 +28,29 @@ const GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK = {
 };
 
 describe("watched-movie", () => {
-  let test;
-
   beforeAll(() => {
     Globals.assign({
       skipAnimation: true,
     });
   });
 
-  beforeEach(() => {
-    test = {
-      props: {
-        movie: buildMovieMock({ watchedOn: "2021-09-04T14:00:00.000Z" }),
-        right: false,
-        isEditing: false,
-        onEditMovie: vi.fn(),
-        onSave: vi.fn(),
-        onCancel: vi.fn(),
-        onDelete: vi.fn(),
-      },
+  beforeEach((context) => {
+    context.props = {
+      movie: buildMovieMock({ watchedOn: "2021-09-04T14:00:00.000Z" }),
+      right: false,
+      isEditing: false,
+      onEditMovie: vi.fn(),
+      onSave: vi.fn(),
+      onCancel: vi.fn(),
+      onDelete: vi.fn(),
     };
   });
 
   afterEach(() => vi.clearAllMocks());
 
-  it("should render the title, date and poster", async () => {
+  it("should render the title, date and poster", async ({ props }) => {
     const { getByLabelText, getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
+      <WatchedMovie {...props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
@@ -71,13 +67,12 @@ describe("watched-movie", () => {
     expect(getByLabelText("Test Movie Poster")).toBeInTheDocument();
   });
 
-  it("should render the poster followed by the info when left-aligned", async () => {
-    const { getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+  it("should render the poster followed by the info when left-aligned", async ({
+    props,
+  }) => {
+    const { getByTestId } = renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     // Test the order. When left-aligned, the poster should come before the info
     const [posterNode, infoNode] = getByTestId("content").childNodes;
@@ -86,9 +81,11 @@ describe("watched-movie", () => {
     );
   });
 
-  it("should render the info followed by the poster when right-aligned", async () => {
+  it("should render the info followed by the poster when right-aligned", async ({
+    props,
+  }) => {
     const { getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} right />,
+      <WatchedMovie {...props} right />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
@@ -101,47 +98,47 @@ describe("watched-movie", () => {
     );
   });
 
-  it("should render the date correctly when the breakpoint is small", async () => {
+  it("should render the date correctly when the breakpoint is small", async ({
+    props,
+  }) => {
     // Mock "small"
     // eslint-disable-next-line no-import-assign
     mui.useMediaQuery = vi
       .fn()
       .mockImplementation((query) => query === "(max-width: 550px)");
 
-    const { getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    const { getByTestId } = renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     expect(
       within(getByTestId("info")).getByText("Saturday, Sep 4th, 2021")
     ).toBeInTheDocument();
   });
 
-  it("should render the date correctly when the breakpoint is xsmall", async () => {
+  it("should render the date correctly when the breakpoint is xsmall", async ({
+    props,
+  }) => {
     // Mock "xsmall"
     // eslint-disable-next-line no-import-assign
     mui.useMediaQuery = vi
       .fn()
       .mockImplementation((query) => query === "(max-width: 430px)");
 
-    const { getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
-      {
-        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+    const { getByTestId } = renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
 
     expect(
       within(getByTestId("info")).getByText("Sat, Sep 4th, 2021")
     ).toBeInTheDocument();
   });
 
-  it("should show the date picker inline at larger sizes", async () => {
-    const { getByLabelText, getByTestId, queryByRole } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
+  it("should show the date picker inline at larger sizes", async ({
+    props,
+  }) => {
+    const { getByLabelText, findByTestId, queryByRole } = renderWithProviders(
+      <WatchedMovie {...props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
@@ -149,22 +146,22 @@ describe("watched-movie", () => {
 
     fireEvent.click(getByLabelText("Test Movie"));
 
-    await waitFor(() => {
-      expect(getByTestId("datePicker")).toBeInTheDocument();
-    });
+    expect(await findByTestId("datePicker")).toBeInTheDocument();
 
     expect(queryByRole("presentation")).not.toBeInTheDocument();
   });
 
-  it("should show the date picker in a drawer at small size", async () => {
+  it("should show the date picker in a drawer at small size", async ({
+    props,
+  }) => {
     // Mock "small"
     // eslint-disable-next-line no-import-assign
     mui.useMediaQuery = vi
       .fn()
       .mockImplementation((query) => query === "(max-width: 550px)");
 
-    const { getByLabelText, getByRole } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
+    const { getByLabelText, getByRole, findByRole } = renderWithProviders(
+      <WatchedMovie {...props} />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
@@ -172,66 +169,58 @@ describe("watched-movie", () => {
 
     fireEvent.click(getByLabelText("Test Movie"));
 
-    await waitFor(() => {
-      expect(getByRole("presentation")).toBeInTheDocument();
-    });
+    expect(await findByRole("presentation")).toBeInTheDocument();
 
     expect(
       within(getByRole("presentation")).getByTestId("datePicker")
     ).toBeInTheDocument();
   });
 
-  it("should call onSave with the new date", async () => {
-    const { getByLabelText, getByRole, getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
-      {
+  it("should call onSave with the new date", async ({ props }) => {
+    const { getByLabelText, getByRole, getByTestId, findByTestId } =
+      renderWithProviders(<WatchedMovie {...props} />, {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+      });
 
     fireEvent.click(getByLabelText("Test Movie"));
 
-    await waitFor(() => {
-      expect(getByTestId("datePicker")).toBeInTheDocument();
-    });
+    expect(await findByTestId("datePicker")).toBeInTheDocument();
 
     fireEvent.click(getByRole("button", { name: /10th/ }));
 
     fireEvent.click(getByTestId("CalendarCheckIcon"));
 
-    expect(test.props.onSave).toHaveBeenCalledWith(
+    expect(props.onSave).toHaveBeenCalledWith(
       expect.objectContaining({
         watchedOn: expect.stringContaining("2021-09-10"),
       })
     );
   });
 
-  it("should call onCancel when clicking the cancel button on the date picker", async () => {
-    const { getByLabelText, getByRole, getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
-      {
+  it("should call onCancel when clicking the cancel button on the date picker", async ({
+    props,
+  }) => {
+    const { getByLabelText, getByRole, getByTestId, findByTestId } =
+      renderWithProviders(<WatchedMovie {...props} />, {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+      });
 
     fireEvent.click(getByLabelText("Test Movie"));
 
-    await waitFor(() => {
-      expect(getByTestId("datePicker")).toBeInTheDocument();
-    });
+    expect(await findByTestId("datePicker")).toBeInTheDocument();
 
     fireEvent.click(getByRole("button", { name: /10th/ }));
 
     fireEvent.click(getByTestId("CloseIcon"));
 
-    expect(test.props.onCancel).toHaveBeenCalled();
+    expect(props.onCancel).toHaveBeenCalled();
 
     // TODO: This should test that the date picker is removed after the animation complete.
   });
 
-  it("should call onCancel when clicking the backdrop", async () => {
+  it("should call onCancel when clicking the backdrop", async ({ props }) => {
     const { getByLabelText } = renderWithProviders(
-      <WatchedMovie {...test.props} isEditing />,
+      <WatchedMovie {...props} isEditing />,
       {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
       }
@@ -239,28 +228,24 @@ describe("watched-movie", () => {
 
     fireEvent.click(getByLabelText("Test Movie"));
 
-    expect(test.props.onCancel).toHaveBeenCalled();
+    expect(props.onCancel).toHaveBeenCalled();
   });
 
-  it("should call onDelete with the correct movie data", async () => {
-    const { getByLabelText, getByRole, getByTestId } = renderWithProviders(
-      <WatchedMovie {...test.props} />,
-      {
+  it("should call onDelete with the correct movie data", async ({ props }) => {
+    const { getByLabelText, getByRole, getByTestId, findByTestId } =
+      renderWithProviders(<WatchedMovie {...props} />, {
         mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
-      }
-    );
+      });
 
     fireEvent.click(getByLabelText("Test Movie"));
 
-    await waitFor(() => {
-      expect(getByTestId("datePicker")).toBeInTheDocument();
-    });
+    expect(await findByTestId("datePicker")).toBeInTheDocument();
 
     fireEvent.click(getByRole("button", { name: /10th/ }));
 
     fireEvent.click(getByTestId("DeleteIcon"));
 
-    expect(test.props.onCancel).toHaveBeenCalled();
-    expect(test.props.onDelete).toHaveBeenCalledWith(test.props.movie);
+    expect(props.onCancel).toHaveBeenCalled();
+    expect(props.onDelete).toHaveBeenCalledWith(props.movie);
   });
 });

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
@@ -3,7 +3,7 @@ import { buildMovieMock } from "../../../../../../utils/build-movie-mock";
 import WatchedMovie from "./watched-movie";
 import { vi } from "vitest";
 import { buildThirdPartyMovieMock } from "../../../../../../utils/build-third-party-movie-mock";
-import { fireEvent, within, screen } from "@testing-library/react";
+import { within, screen } from "@testing-library/react";
 import * as mui from "@mui/material";
 import { Globals } from "@react-spring/web";
 import { GET_THIRD_PARTY_MOVIE_FULL_DETAILS } from "../../../../../../graphql/queries";
@@ -132,12 +132,13 @@ describe("watched-movie", () => {
 
   it("should show the date picker inline at larger sizes", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    fireEvent.click(screen.getByLabelText("Test Movie"));
+    await user.click(screen.getByLabelText("Test Movie"));
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
@@ -146,6 +147,7 @@ describe("watched-movie", () => {
 
   it("should show the date picker in a drawer at small size", async ({
     props,
+    user,
   }) => {
     // Mock "small"
     // eslint-disable-next-line no-import-assign
@@ -157,7 +159,7 @@ describe("watched-movie", () => {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    fireEvent.click(screen.getByLabelText("Test Movie"));
+    await user.click(screen.getByLabelText("Test Movie"));
 
     expect(await screen.findByRole("presentation")).toBeInTheDocument();
 
@@ -166,18 +168,18 @@ describe("watched-movie", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call onSave with the new date", async ({ props }) => {
+  it("should call onSave with the new date", async ({ props, user }) => {
     renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    fireEvent.click(screen.getByLabelText("Test Movie"));
+    await user.click(screen.getByLabelText("Test Movie"));
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /10th/ }));
+    await user.click(screen.getByRole("button", { name: /10th/ }));
 
-    fireEvent.click(screen.getByTestId("CalendarCheckIcon"));
+    await user.click(screen.getByTestId("CalendarCheckIcon"));
 
     expect(props.onSave).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -188,46 +190,53 @@ describe("watched-movie", () => {
 
   it("should call onCancel when clicking the cancel button on the date picker", async ({
     props,
+    user,
   }) => {
     renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    fireEvent.click(screen.getByLabelText("Test Movie"));
+    await user.click(screen.getByLabelText("Test Movie"));
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /10th/ }));
+    await user.click(screen.getByRole("button", { name: /10th/ }));
 
-    fireEvent.click(screen.getByTestId("CloseIcon"));
+    await user.click(screen.getByTestId("CloseIcon"));
 
     expect(props.onCancel).toHaveBeenCalled();
 
     // TODO: This should test that the date picker is removed after the animation complete.
   });
 
-  it("should call onCancel when clicking the backdrop", async ({ props }) => {
+  it("should call onCancel when clicking the backdrop", async ({
+    props,
+    user,
+  }) => {
     renderWithProviders(<WatchedMovie {...props} isEditing />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    fireEvent.click(screen.getByLabelText("Test Movie"));
+    await user.click(screen.getByLabelText("Test Movie"));
 
     expect(props.onCancel).toHaveBeenCalled();
   });
 
-  it("should call onDelete with the correct movie data", async ({ props }) => {
+  it("should call onDelete with the correct movie data", async ({
+    props,
+    user,
+  }) => {
     renderWithProviders(<WatchedMovie {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
 
-    fireEvent.click(screen.getByLabelText("Test Movie"));
+    await user.click(screen.getByLabelText("Test Movie"));
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /10th/ }));
+    await user.click(screen.getByRole("button", { name: /10th/ }));
 
-    fireEvent.click(screen.getByTestId("DeleteIcon"));
+    await user.click(screen.getByTestId("DeleteIcon"));
 
     expect(props.onCancel).toHaveBeenCalled();
     expect(props.onDelete).toHaveBeenCalledWith(props.movie);

--- a/packages/web/src/components/app/components/watched/watched.error.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.error.test.jsx
@@ -1,5 +1,5 @@
 import { Watched } from "./watched";
-import { fireEvent, within } from "@testing-library/react";
+import { fireEvent, within, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import { vi } from "vitest";
 import { GET_MOVIES } from "../../../../graphql/queries";
@@ -53,26 +53,25 @@ const GET_MOVIES_MOCK = {
 
 describe("watched - error", () => {
   it("should show the error", async () => {
-    const { getByText, findByText, getByRole } = renderWithProviders(
-      <Watched />,
-      {
-        moviesMock: GET_MOVIES_MOCK,
-        mocks: [REMOVE_MOVIE_ERROR_MOCK],
-      }
-    );
+    renderWithProviders(<Watched />, {
+      moviesMock: GET_MOVIES_MOCK,
+      mocks: [REMOVE_MOVIE_ERROR_MOCK],
+    });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
+      within(screen.getByText(/Bourne/)).getByRole("button", {
+        name: "DELETE",
+      })
     );
 
-    const dialog = getByRole("dialog");
+    const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText(/Bourne.*removed/)).toBeInTheDocument();
 
     fireEvent.click(within(dialog).getByText("Delete"));
 
-    expect(await findByText(/Houston/)).toBeInTheDocument();
+    expect(await screen.findByText(/Houston/)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/watched/watched.error.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.error.test.jsx
@@ -53,7 +53,7 @@ const GET_MOVIES_MOCK = {
 
 describe("watched - error", () => {
   it("should show the error", async () => {
-    const { getByText, getByRole } = await renderWithProviders(<Watched />, {
+    const { getByText, getByRole } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
       mocks: [REMOVE_MOVIE_ERROR_MOCK],
     });

--- a/packages/web/src/components/app/components/watched/watched.error.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.error.test.jsx
@@ -1,5 +1,5 @@
 import { Watched } from "./watched";
-import { fireEvent, within, screen } from "@testing-library/react";
+import { within, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import { vi } from "vitest";
 import { GET_MOVIES } from "../../../../graphql/queries";
@@ -52,7 +52,7 @@ const GET_MOVIES_MOCK = {
 };
 
 describe("watched - error", () => {
-  it("should show the error", async () => {
+  it("should show the error", async ({ user }) => {
     renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
       mocks: [REMOVE_MOVIE_ERROR_MOCK],
@@ -60,7 +60,7 @@ describe("watched - error", () => {
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", {
         name: "DELETE",
       })
@@ -70,7 +70,7 @@ describe("watched - error", () => {
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText(/Bourne.*removed/)).toBeInTheDocument();
 
-    fireEvent.click(within(dialog).getByText("Delete"));
+    await user.click(within(dialog).getByText("Delete"));
 
     expect(await screen.findByText(/Houston/)).toBeInTheDocument();
   });

--- a/packages/web/src/components/app/components/watched/watched.error.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.error.test.jsx
@@ -1,5 +1,5 @@
 import { Watched } from "./watched";
-import { fireEvent, waitFor, within } from "@testing-library/react";
+import { fireEvent, within } from "@testing-library/react";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import { vi } from "vitest";
 import { GET_MOVIES } from "../../../../graphql/queries";
@@ -53,12 +53,15 @@ const GET_MOVIES_MOCK = {
 
 describe("watched - error", () => {
   it("should show the error", async () => {
-    const { getByText, getByRole } = renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
-      mocks: [REMOVE_MOVIE_ERROR_MOCK],
-    });
+    const { getByText, findByText, getByRole } = renderWithProviders(
+      <Watched />,
+      {
+        moviesMock: GET_MOVIES_MOCK,
+        mocks: [REMOVE_MOVIE_ERROR_MOCK],
+      }
+    );
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
       within(getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
@@ -70,6 +73,6 @@ describe("watched - error", () => {
 
     fireEvent.click(within(dialog).getByText("Delete"));
 
-    await waitFor(() => expect(getByText(/Houston/)).toBeInTheDocument());
+    expect(await findByText(/Houston/)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/watched/watched.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.test.jsx
@@ -1,5 +1,5 @@
 import { Watched } from "./watched";
-import { fireEvent, waitFor, within } from "@testing-library/react";
+import { fireEvent, waitFor, within, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import { vi } from "vitest";
 import { GET_MOVIES } from "../../../../graphql/queries";
@@ -90,11 +90,11 @@ const GET_MOVIES_MOCK = {
 
 describe("watched", () => {
   it("should render the movies as watched movie items in reverse chronological order", async () => {
-    const { findByText } = renderWithProviders(<Watched />, {
+    renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     const items = document.querySelectorAll("[data-right]");
 
@@ -111,43 +111,45 @@ describe("watched", () => {
   });
 
   it("should show the delete dialog on delete action and do the 'cancel' action", async () => {
-    const { getByText, findByText, getByRole, queryByRole } =
-      renderWithProviders(<Watched />, {
-        moviesMock: GET_MOVIES_MOCK,
-      });
+    renderWithProviders(<Watched />, {
+      moviesMock: GET_MOVIES_MOCK,
+    });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
     );
 
-    const dialog = getByRole("dialog");
+    const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText(/Bourne.*removed/)).toBeInTheDocument();
 
     fireEvent.click(within(dialog).getByText("Cancel"));
-    await waitFor(() => expect(queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
   });
 
   it("should show the delete dialog on delete action and do the 'delete' action", async () => {
-    const { getByText, findByText, getByRole, queryByRole } =
-      renderWithProviders(<Watched />, {
-        moviesMock: GET_MOVIES_MOCK,
-      });
+    renderWithProviders(<Watched />, {
+      moviesMock: GET_MOVIES_MOCK,
+    });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
     );
 
-    const dialog = getByRole("dialog");
+    const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText(/Bourne.*removed/)).toBeInTheDocument();
 
     fireEvent.click(within(dialog).getByText("Delete"));
-    await waitFor(() => expect(queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
 
     expect(removeMovieMock).toHaveBeenCalledWith({
       optimisticResponse: {
@@ -164,42 +166,42 @@ describe("watched", () => {
   });
 
   it("should enable editing", async () => {
-    const { getByText, findByText } = renderWithProviders(<Watched />, {
+    renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
     );
 
     expect(
-      within(getByText(/Bourne/)).getByText("Editing: true")
+      within(screen.getByText(/Bourne/)).getByText("Editing: true")
     ).toBeInTheDocument();
   });
 
   it("should save the movie and disable editing", async () => {
-    const { getByText, findByText } = renderWithProviders(<Watched />, {
+    renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
     );
 
     expect(
-      within(getByText(/Bourne/)).getByText("Editing: true")
+      within(screen.getByText(/Bourne/)).getByText("Editing: true")
     ).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "SAVE" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "SAVE" })
     );
 
     expect(
-      within(getByText(/Bourne/)).getByText("Editing: false")
+      within(screen.getByText(/Bourne/)).getByText("Editing: false")
     ).toBeInTheDocument();
 
     expect(editMovieMock).toHaveBeenCalledWith({
@@ -219,26 +221,26 @@ describe("watched", () => {
   });
 
   it("should cancel editing", async () => {
-    const { getByText, findByText } = renderWithProviders(<Watched />, {
+    renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    expect(await findByText(/Bourne/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
     );
 
     expect(
-      within(getByText(/Bourne/)).getByText("Editing: true")
+      within(screen.getByText(/Bourne/)).getByText("Editing: true")
     ).toBeInTheDocument();
 
     fireEvent.click(
-      within(getByText(/Bourne/)).getByRole("button", { name: "CANCEL" })
+      within(screen.getByText(/Bourne/)).getByRole("button", { name: "CANCEL" })
     );
 
     expect(
-      within(getByText(/Bourne/)).getByText("Editing: false")
+      within(screen.getByText(/Bourne/)).getByText("Editing: false")
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/app/components/watched/watched.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.test.jsx
@@ -1,5 +1,5 @@
 import { Watched } from "./watched";
-import { fireEvent, waitFor, within, screen } from "@testing-library/react";
+import { waitFor, within, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../utils/render-with-providers";
 import { vi } from "vitest";
 import { GET_MOVIES } from "../../../../graphql/queries";
@@ -110,14 +110,16 @@ describe("watched", () => {
     });
   });
 
-  it("should show the delete dialog on delete action and do the 'cancel' action", async () => {
+  it("should show the delete dialog on delete action and do the 'cancel' action", async ({
+    user,
+  }) => {
     renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
     );
 
@@ -125,20 +127,22 @@ describe("watched", () => {
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText(/Bourne.*removed/)).toBeInTheDocument();
 
-    fireEvent.click(within(dialog).getByText("Cancel"));
+    await user.click(within(dialog).getByText("Cancel"));
     await waitFor(() =>
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     );
   });
 
-  it("should show the delete dialog on delete action and do the 'delete' action", async () => {
+  it("should show the delete dialog on delete action and do the 'delete' action", async ({
+    user,
+  }) => {
     renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
     );
 
@@ -146,7 +150,7 @@ describe("watched", () => {
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText(/Bourne.*removed/)).toBeInTheDocument();
 
-    fireEvent.click(within(dialog).getByText("Delete"));
+    await user.click(within(dialog).getByText("Delete"));
     await waitFor(() =>
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     );
@@ -165,14 +169,14 @@ describe("watched", () => {
     });
   });
 
-  it("should enable editing", async () => {
+  it("should enable editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
     );
 
@@ -181,14 +185,14 @@ describe("watched", () => {
     ).toBeInTheDocument();
   });
 
-  it("should save the movie and disable editing", async () => {
+  it("should save the movie and disable editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
     );
 
@@ -196,7 +200,7 @@ describe("watched", () => {
       within(screen.getByText(/Bourne/)).getByText("Editing: true")
     ).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "SAVE" })
     );
 
@@ -220,14 +224,14 @@ describe("watched", () => {
     });
   });
 
-  it("should cancel editing", async () => {
+  it("should cancel editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
     );
 
@@ -235,7 +239,7 @@ describe("watched", () => {
       within(screen.getByText(/Bourne/)).getByText("Editing: true")
     ).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       within(screen.getByText(/Bourne/)).getByRole("button", { name: "CANCEL" })
     );
 

--- a/packages/web/src/components/app/components/watched/watched.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.test.jsx
@@ -90,7 +90,7 @@ const GET_MOVIES_MOCK = {
 
 describe("watched", () => {
   it("should render the movies as watched movie items in reverse chronological order", async () => {
-    const { getByText } = await renderWithProviders(<Watched />, {
+    const { getByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
@@ -111,7 +111,7 @@ describe("watched", () => {
   });
 
   it("should show the delete dialog on delete action and do the 'cancel' action", async () => {
-    const { getByText, getByRole, queryByRole } = await renderWithProviders(
+    const { getByText, getByRole, queryByRole } = renderWithProviders(
       <Watched />,
       {
         moviesMock: GET_MOVIES_MOCK,
@@ -133,7 +133,7 @@ describe("watched", () => {
   });
 
   it("should show the delete dialog on delete action and do the 'delete' action", async () => {
-    const { getByText, getByRole, queryByRole } = await renderWithProviders(
+    const { getByText, getByRole, queryByRole } = renderWithProviders(
       <Watched />,
       {
         moviesMock: GET_MOVIES_MOCK,
@@ -168,7 +168,7 @@ describe("watched", () => {
   });
 
   it("should enable editing", async () => {
-    const { getByText } = await renderWithProviders(<Watched />, {
+    const { getByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
@@ -183,12 +183,12 @@ describe("watched", () => {
     ).toBeInTheDocument();
   });
 
-  it("should save the move and disable editing", async () => {
-    const { getByText } = await renderWithProviders(<Watched />, {
+  it("should save the movie and disable editing", async () => {
+    const { getByText, findByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
       within(getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
@@ -223,7 +223,7 @@ describe("watched", () => {
   });
 
   it("should cancel editing", async () => {
-    const { getByText } = await renderWithProviders(<Watched />, {
+    const { getByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 

--- a/packages/web/src/components/app/components/watched/watched.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.test.jsx
@@ -90,11 +90,11 @@ const GET_MOVIES_MOCK = {
 
 describe("watched", () => {
   it("should render the movies as watched movie items in reverse chronological order", async () => {
-    const { getByText } = renderWithProviders(<Watched />, {
+    const { findByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     const items = document.querySelectorAll("[data-right]");
 
@@ -111,14 +111,12 @@ describe("watched", () => {
   });
 
   it("should show the delete dialog on delete action and do the 'cancel' action", async () => {
-    const { getByText, getByRole, queryByRole } = renderWithProviders(
-      <Watched />,
-      {
+    const { getByText, findByText, getByRole, queryByRole } =
+      renderWithProviders(<Watched />, {
         moviesMock: GET_MOVIES_MOCK,
-      }
-    );
+      });
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
       within(getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
@@ -133,14 +131,12 @@ describe("watched", () => {
   });
 
   it("should show the delete dialog on delete action and do the 'delete' action", async () => {
-    const { getByText, getByRole, queryByRole } = renderWithProviders(
-      <Watched />,
-      {
+    const { getByText, findByText, getByRole, queryByRole } =
+      renderWithProviders(<Watched />, {
         moviesMock: GET_MOVIES_MOCK,
-      }
-    );
+      });
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
       within(getByText(/Bourne/)).getByRole("button", { name: "DELETE" })
@@ -168,11 +164,11 @@ describe("watched", () => {
   });
 
   it("should enable editing", async () => {
-    const { getByText } = renderWithProviders(<Watched />, {
+    const { getByText, findByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
       within(getByText(/Bourne/)).getByRole("button", { name: "EDIT" })
@@ -223,11 +219,11 @@ describe("watched", () => {
   });
 
   it("should cancel editing", async () => {
-    const { getByText } = renderWithProviders(<Watched />, {
+    const { getByText, findByText } = renderWithProviders(<Watched />, {
       moviesMock: GET_MOVIES_MOCK,
     });
 
-    await waitFor(() => expect(getByText(/Bourne/)).toBeInTheDocument());
+    expect(await findByText(/Bourne/)).toBeInTheDocument();
 
     fireEvent.click(
       within(getByText(/Bourne/)).getByRole("button", { name: "EDIT" })

--- a/packages/web/src/utils/render-with-providers.jsx
+++ b/packages/web/src/utils/render-with-providers.jsx
@@ -24,7 +24,7 @@ vi.mock("@auth0/auth0-react", () => ({
   }),
 }));
 
-export const renderWithProviders = async (children, options) => {
+export const renderWithProviders = (children, options) => {
   options = {
     ...{
       mocks: [],
@@ -53,9 +53,6 @@ export const renderWithProviders = async (children, options) => {
 
   const result = render(children, { wrapper: RenderWrapper, ...options });
 
-  // Await for one tick to make sure that the mock query responses are not in the loading state
-  await waitFor(() => new Promise((resolve) => setTimeout(resolve, 0)));
-
   return result;
 };
 
@@ -66,7 +63,7 @@ export const renderWithProviders = async (children, options) => {
  * @param route The full URL path to be matched against "routePath". For example, "list/1234" would match the routePath so that useParams will return id=1234.
  * @param options Options for renderWIthProviders. Note that if "route" is included it will be overriden by the route argument.
  */
-export const renderWithProvidersAsRoute = async (
+export const renderWithProvidersAsRoute = (
   children,
   routePath,
   route,

--- a/packages/web/src/utils/render-with-providers.jsx
+++ b/packages/web/src/utils/render-with-providers.jsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { AppProvider } from "../context/app-context";
 import { GET_LISTS, GET_MOVIES } from "../graphql/queries";

--- a/packages/web/vitest-setup.js
+++ b/packages/web/vitest-setup.js
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
-import { beforeAll, vi } from "vitest";
+import { beforeAll, beforeEach, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
 
 beforeAll(() => {
   // Define a mock for intersection observer.
@@ -8,4 +9,8 @@ beforeAll(() => {
     observe: vi.fn(),
     unobserve: vi.fn(),
   }));
+});
+
+beforeEach((context) => {
+  context.user = userEvent.setup();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,14 +22,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.6.9":
-  version: 3.7.11
-  resolution: "@apollo/client@npm:3.7.11"
+"@apollo/client@npm:^3.7.14":
+  version: 3.7.15
+  resolution: "@apollo/client@npm:3.7.15"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
     "@wry/context": ^0.7.0
     "@wry/equality": ^0.5.0
-    "@wry/trie": ^0.3.0
+    "@wry/trie": ^0.4.0
     graphql-tag: ^2.12.6
     hoist-non-react-statics: ^3.3.2
     optimism: ^0.16.2
@@ -54,7 +54,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 56fa501dc27b68b01c054ffd5642fcfedb16ee4653e819fb92d1b6cae834160f1274a961f335812f4781bbbbdf3bb6f851f07a7351f95d8945740cc79fa2d58f
+  checksum: a33e56847dfb7d6176ffb3cd4d3ff2c548826ce51280a6c8f70e3d75daf9d3a287e79bf3d86ea0b16e39218c90d8a7b4f528eb340055387cf9137705970c0f59
   languageName: node
   linkType: hard
 
@@ -1566,6 +1566,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-arm64@npm:0.17.19"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.15.18":
   version: 0.15.18
   resolution: "@esbuild/android-arm@npm:0.15.18"
@@ -1573,10 +1580,157 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-arm@npm:0.17.19"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-x64@npm:0.17.19"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/darwin-arm64@npm:0.17.19"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/darwin-x64@npm:0.17.19"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/freebsd-arm64@npm:0.17.19"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/freebsd-x64@npm:0.17.19"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-arm64@npm:0.17.19"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-arm@npm:0.17.19"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-ia32@npm:0.17.19"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.15.18":
   version: 0.15.18
   resolution: "@esbuild/linux-loong64@npm:0.15.18"
   conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-loong64@npm:0.17.19"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-mips64el@npm:0.17.19"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-ppc64@npm:0.17.19"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-riscv64@npm:0.17.19"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-s390x@npm:0.17.19"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-x64@npm:0.17.19"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/netbsd-x64@npm:0.17.19"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/openbsd-x64@npm:0.17.19"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/sunos-x64@npm:0.17.19"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-arm64@npm:0.17.19"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-ia32@npm:0.17.19"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-x64@npm:0.17.19"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1837,6 +1991,13 @@ __metadata:
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.4.13":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
   languageName: node
   linkType: hard
 
@@ -2466,6 +2627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^4.3.5":
+  version: 4.3.5
+  resolution: "@types/chai@npm:4.3.5"
+  checksum: c8f26a88c6b5b53a3275c7f5ff8f107028e3cbb9ff26795fff5f3d9dea07106a54ce9e2dce5e40347f7c4cc35657900aaf0c83934a25a1ae12e61e0f5516e431
+  languageName: node
+  linkType: hard
+
 "@types/connect@npm:*":
   version: 3.4.35
   resolution: "@types/connect@npm:3.4.35"
@@ -2920,12 +3088,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:0.31.1":
+  version: 0.31.1
+  resolution: "@vitest/expect@npm:0.31.1"
+  dependencies:
+    "@vitest/spy": 0.31.1
+    "@vitest/utils": 0.31.1
+    chai: ^4.3.7
+  checksum: 0d1e135ae753d913231eae830da00ee42afca53d354898fb43f97e82398dcf17298c02e9989dd6b19b9b2909989248ef76d203d63f6af6f9159dc96959ea654b
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:0.31.1":
+  version: 0.31.1
+  resolution: "@vitest/runner@npm:0.31.1"
+  dependencies:
+    "@vitest/utils": 0.31.1
+    concordance: ^5.0.4
+    p-limit: ^4.0.0
+    pathe: ^1.1.0
+  checksum: cc8702e21b799d5e941409cb2afe6d0e576b4f3ac99df4a1393a8cd11b57f6b0b06e756cc24e2739812d095fbfd0824e22e861dbd6a71769ca387d485ade6fb5
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:0.31.1":
+  version: 0.31.1
+  resolution: "@vitest/snapshot@npm:0.31.1"
+  dependencies:
+    magic-string: ^0.30.0
+    pathe: ^1.1.0
+    pretty-format: ^27.5.1
+  checksum: de05fa9136864f26f0804baf3ae8068f67de28015f29047329c84e67fb33be7305c9e52661b016e834d30f4081c136b3b6d8d4054c024a5d52b22a7f90fc4be0
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:0.31.1":
+  version: 0.31.1
+  resolution: "@vitest/spy@npm:0.31.1"
+  dependencies:
+    tinyspy: ^2.1.0
+  checksum: 8b06cf25fcc028c16106ec82f4ceb84d6dfa04d06f651bca4738ce2b99796d1fc4e0c10319767240755eff8ede2bff9d31d5a901fe92828d319c65001581137b
+  languageName: node
+  linkType: hard
+
 "@vitest/ui@npm:^0.22.1":
   version: 0.22.1
   resolution: "@vitest/ui@npm:0.22.1"
   dependencies:
     sirv: ^2.0.2
   checksum: ad82bbcb4d455c16ba2c529b96e84f22d8be515f9cfe6e6bec53b14910beca9ba52e6cdd1e4f444e29af76cbbaa80519b0185ca895a3b3cda81c3989237f9979
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:0.31.1":
+  version: 0.31.1
+  resolution: "@vitest/utils@npm:0.31.1"
+  dependencies:
+    concordance: ^5.0.4
+    loupe: ^2.3.6
+    pretty-format: ^27.5.1
+  checksum: 58016c185455e3814632cb77e37368c846bde5e342f8b4a66fa229bde64f455ca39abebc9c12e2483696ee38bc17b3c4300379f7a3b18d1087f24f474448a8d8
   languageName: node
   linkType: hard
 
@@ -2953,6 +3175,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.0
   checksum: 151d06b519e1ff1c3acf6ee6846161b1d7d50bbecd4c48e5cd1b05f9e37c30602aff02e88f20105f6e6c54ae4123f9c4eb7715044d7fd927d4ba4ec3e755cd36
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.4.0":
+  version: 0.4.3
+  resolution: "@wry/trie@npm:0.4.3"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 106e021125cfafd22250a6631a0438a6a3debae7bd73f6db87fe42aa0757fe67693db0dfbe200ae1f60ba608c3e09ddb8a4e2b3527d56ed0a7e02aa0ee4c94e1
   languageName: node
   linkType: hard
 
@@ -3006,14 +3237,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.0.2":
+"acorn-walk@npm:^8.0.2, acorn-walk@npm:^8.2.0":
   version: 8.2.0
   resolution: "acorn-walk@npm:8.2.0"
   checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.1.0, acorn@npm:^8.8.0, acorn@npm:^8.8.1":
+"acorn@npm:^8.1.0, acorn@npm:^8.8.0, acorn@npm:^8.8.1, acorn@npm:^8.8.2":
   version: 8.8.2
   resolution: "acorn@npm:8.8.2"
   bin:
@@ -3431,6 +3662,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"blueimp-md5@npm:^2.10.0":
+  version: 2.19.0
+  resolution: "blueimp-md5@npm:2.19.0"
+  checksum: 28095dcbd2c67152a2938006e8d7c74c3406ba6556071298f872505432feb2c13241b0476644160ee0a5220383ba94cb8ccdac0053b51f68d168728f9c382530
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:1.20.1":
   version: 1.20.1
   resolution: "body-parser@npm:1.20.1"
@@ -3584,6 +3822,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^16.1.0":
   version: 16.1.3
   resolution: "cacache@npm:16.1.3"
@@ -3634,7 +3879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^4.3.6":
+"chai@npm:^4.3.6, chai@npm:^4.3.7":
   version: 4.3.7
   resolution: "chai@npm:4.3.7"
   dependencies:
@@ -3847,6 +4092,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concordance@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "concordance@npm:5.0.4"
+  dependencies:
+    date-time: ^3.1.0
+    esutils: ^2.0.3
+    fast-diff: ^1.2.0
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.15
+    md5-hex: ^3.0.1
+    semver: ^7.3.2
+    well-known-symbols: ^2.0.0
+  checksum: 749153ba711492feb7c3d2f5bb04c107157440b3e39509bd5dd19ee7b3ac751d1e4cd75796d9f702e0a713312dbc661421c68aa4a2c34d5f6d91f47e3a1c64a6
+  languageName: node
+  linkType: hard
+
 "console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
@@ -4015,6 +4276,15 @@ __metadata:
   version: 2.29.3
   resolution: "date-fns@npm:2.29.3"
   checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
+  languageName: node
+  linkType: hard
+
+"date-time@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "date-time@npm:3.1.0"
+  dependencies:
+    time-zone: ^1.0.0
+  checksum: f9cfcd1b15dfeabab15c0b9d18eb9e4e2d9d4371713564178d46a8f91ad577a290b5178b80050718d02d9c0cf646f8a875011e12d1ed05871e9f72c72c8a8fe6
   languageName: node
   linkType: hard
 
@@ -4603,6 +4873,83 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:^0.17.5":
+  version: 0.17.19
+  resolution: "esbuild@npm:0.17.19"
+  dependencies:
+    "@esbuild/android-arm": 0.17.19
+    "@esbuild/android-arm64": 0.17.19
+    "@esbuild/android-x64": 0.17.19
+    "@esbuild/darwin-arm64": 0.17.19
+    "@esbuild/darwin-x64": 0.17.19
+    "@esbuild/freebsd-arm64": 0.17.19
+    "@esbuild/freebsd-x64": 0.17.19
+    "@esbuild/linux-arm": 0.17.19
+    "@esbuild/linux-arm64": 0.17.19
+    "@esbuild/linux-ia32": 0.17.19
+    "@esbuild/linux-loong64": 0.17.19
+    "@esbuild/linux-mips64el": 0.17.19
+    "@esbuild/linux-ppc64": 0.17.19
+    "@esbuild/linux-riscv64": 0.17.19
+    "@esbuild/linux-s390x": 0.17.19
+    "@esbuild/linux-x64": 0.17.19
+    "@esbuild/netbsd-x64": 0.17.19
+    "@esbuild/openbsd-x64": 0.17.19
+    "@esbuild/sunos-x64": 0.17.19
+    "@esbuild/win32-arm64": 0.17.19
+    "@esbuild/win32-ia32": 0.17.19
+    "@esbuild/win32-x64": 0.17.19
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: ac11b1a5a6008e4e37ccffbd6c2c054746fc58d0ed4a2f9ee643bd030cfcea9a33a235087bc777def8420f2eaafb3486e76adb7bdb7241a9143b43a69a10afd8
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -4858,7 +5205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esutils@npm:^2.0.2":
+"esutils@npm:^2.0.2, esutils@npm:^2.0.3":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
@@ -4945,6 +5292,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: d22d371b994fdc8cce9ff510d7b8dc4da70ac327bcba20df607dd5b9cae9f908f4d1028f5fe467650f058d1e7270235ae0b8230809a262b4df587a3b3aa216c3
   languageName: node
   linkType: hard
 
@@ -6006,6 +6360,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-string-escape@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "js-string-escape@npm:1.0.1"
+  checksum: f11e0991bf57e0c183b55c547acec85bd2445f043efc9ea5aa68b41bd2a3e7d3ce94636cb233ae0d84064ba4c1a505d32e969813c5b13f81e7d4be12c59256fe
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -6108,6 +6469,13 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 2a7436a93393830bce797d4626275152e37e877b265e94ca69c99e3d20c2b9dab021279146a39cdb700e71b2dd32a4cebd1514cd57cee102b1af906ce5040349
+  languageName: node
+  linkType: hard
+
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "jsonc-parser@npm:3.2.0"
+  checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
   languageName: node
   linkType: hard
 
@@ -6368,7 +6736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"local-pkg@npm:^0.4.2":
+"local-pkg@npm:^0.4.2, local-pkg@npm:^0.4.3":
   version: 0.4.3
   resolution: "local-pkg@npm:0.4.3"
   checksum: 7825aca531dd6afa3a3712a0208697aa4a5cd009065f32e3fb732aafcc42ed11f277b5ac67229222e96f4def55197171cdf3d5522d0381b489d2e5547b407d55
@@ -6505,7 +6873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^2.3.1":
+"loupe@npm:^2.3.1, loupe@npm:^2.3.6":
   version: 2.3.6
   resolution: "loupe@npm:2.3.6"
   dependencies:
@@ -6584,6 +6952,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.0":
+  version: 0.30.0
+  resolution: "magic-string@npm:0.30.0"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.13
+  checksum: 7bdf22e27334d8a393858a16f5f840af63a7c05848c000fd714da5aa5eefa09a1bc01d8469362f25cc5c4a14ec01b46557b7fff8751365522acddf21e57c488d
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -6636,7 +7013,7 @@ __metadata:
     md4k-constants: "*"
     mongodb: ^4.8.1
     typescript: ^4.6.4
-    vitest: ^0.22.1
+    vitest: ^0.31.0
   peerDependencies:
     "@typescript-eslint/eslint-plugin": "*"
     "@typescript-eslint/parser": "*"
@@ -6654,7 +7031,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "md4k-web@workspace:packages/web"
   dependencies:
-    "@apollo/client": ^3.6.9
+    "@apollo/client": ^3.7.14
     "@auth0/auth0-react": ^1.10.2
     "@emotion/react": ^11.10.0
     "@emotion/styled": ^11.10.0
@@ -6696,7 +7073,7 @@ __metadata:
     typescript: ^4.6.4
     uuid: ^8.3.2
     vite: ^3.0.0
-    vitest: ^0.22.1
+    vitest: ^0.31.0
   peerDependencies:
     "@typescript-eslint/eslint-plugin": "*"
     "@typescript-eslint/parser": "*"
@@ -6717,6 +7094,15 @@ __metadata:
     prettier: 2.7.1
   languageName: unknown
   linkType: soft
+
+"md5-hex@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "md5-hex@npm:3.0.1"
+  dependencies:
+    blueimp-md5: ^2.10.0
+  checksum: 6799a19e8bdd3e0c2861b94c1d4d858a89220488d7885c1fa236797e367d0c2e5f2b789e05309307083503f85be3603a9686a5915568a473137d6b4117419cc2
+  languageName: node
+  linkType: hard
 
 "mdi-material-ui@npm:^7.6.0":
   version: 7.6.0
@@ -6930,6 +7316,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "mlly@npm:1.3.0"
+  dependencies:
+    acorn: ^8.8.2
+    pathe: ^1.1.0
+    pkg-types: ^1.0.3
+    ufo: ^1.1.2
+  checksum: aea2a99131b1a1f02a733219317b6466156e150473e0a2f490802eaf2dc66940a21bb68e0ddd5c003360263e674e7dd0bd02da6520c740e6d16fa0edf5efa46e
+  languageName: node
+  linkType: hard
+
 "mongodb-connection-string-url@npm:^2.5.4":
   version: 2.6.0
   resolution: "mongodb-connection-string-url@npm:2.6.0"
@@ -6986,7 +7384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
+"nanoid@npm:^3.3.4, nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
   bin:
@@ -7288,6 +7686,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-limit@npm:4.0.0"
+  dependencies:
+    yocto-queue: ^1.0.0
+  checksum: 01d9d70695187788f984226e16c903475ec6a947ee7b21948d6f597bed788e3112cc7ec2e171c1d37125057a5f45f3da21d8653e04a3a793589e12e9e80e756b
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^5.0.0":
   version: 5.0.0
   resolution: "p-locate@npm:5.0.0"
@@ -7392,6 +7799,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "pathe@npm:1.1.0"
+  checksum: 6b9be9968ea08a90c0824934799707a1c6a1ad22ac1f22080f377e3f75856d5e53a331b01d327329bfce538a14590587cfb250e8e7947f64408797c84c252056
+  languageName: node
+  linkType: hard
+
 "pathval@npm:^1.1.1":
   version: 1.1.1
   resolution: "pathval@npm:1.1.1"
@@ -7429,6 +7843,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg-types@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "pkg-types@npm:1.0.3"
+  dependencies:
+    jsonc-parser: ^3.2.0
+    mlly: ^1.2.0
+    pathe: ^1.1.0
+  checksum: 4b305c834b912ddcc8a0fe77530c0b0321fe340396f84cbb87aecdbc126606f47f2178f23b8639e71a4870f9631c7217aef52ffed0ae17ea2dbbe7e43d116a6e
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.18":
   version: 8.4.21
   resolution: "postcss@npm:8.4.21"
@@ -7437,6 +7862,17 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: e39ac60ccd1542d4f9d93d894048aac0d686b3bb38e927d8386005718e6793dbbb46930f0a523fe382f1bbd843c6d980aaea791252bf5e176180e5a4336d9679
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.23":
+  version: 8.4.24
+  resolution: "postcss@npm:8.4.24"
+  dependencies:
+    nanoid: ^3.3.6
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 814e2126dacfea313588eda09cc99a9b4c26ec55c059188aa7a916d20d26d483483106dc5ff9e560731b59f45c5bb91b945dfadc670aed875cc90ddbbf4e787d
   languageName: node
   linkType: hard
 
@@ -7463,7 +7899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.0.2":
+"pretty-format@npm:^27.0.2, pretty-format@npm:^27.5.1":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
   dependencies:
@@ -7969,6 +8405,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^3.21.0":
+  version: 3.23.0
+  resolution: "rollup@npm:3.23.0"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 0721065cf725c5611815be61d2b01f20b4d0027e17035f6e76384d38396b56cf6ed21a3db78eb004d9db4d24c8a6a19da4563b4ff96b5dd36f0a0f7a3baf85e8
+  languageName: node
+  linkType: hard
+
 "rooks@npm:^5.11.0":
   version: 5.14.1
   resolution: "rooks@npm:5.14.1"
@@ -8070,6 +8520,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.2":
+  version: 7.5.1
+  resolution: "semver@npm:7.5.1"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: d16dbedad53c65b086f79524b9ef766bf38670b2395bdad5c957f824dcc566b624988013564f4812bcace3f9d405355c3635e2007396a39d1bffc71cfec4a2fc
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
@@ -8164,6 +8625,13 @@ __metadata:
     get-intrinsic: ^1.0.2
     object-inspect: ^1.9.0
   checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
+  languageName: node
+  linkType: hard
+
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 8aa5a98640ca09fe00d74416eca97551b3e42991614a3d1b824b115fc1401543650914f651ab1311518177e4d297e80b953f4cd4cd7ea1eabe824e8f2091de01
   languageName: node
   linkType: hard
 
@@ -8323,10 +8791,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.3.2":
+  version: 3.3.3
+  resolution: "std-env@npm:3.3.3"
+  checksum: 6665f6d8bd63aae432d3eb9abbd7322847ad0d902603e6dce1e8051b4f42ceeb4f7f96a4faf70bb05ce65ceee2dc982502b701575c8a58b1bfad29f3dbb19f81
   languageName: node
   linkType: hard
 
@@ -8474,6 +8956,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-literal@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "strip-literal@npm:1.0.1"
+  dependencies:
+    acorn: ^8.8.2
+  checksum: ab40496820f02220390d95cdd620a997168efb69d5bd7d180bc4ef83ca562a95447843d8c7c88b8284879a29cf4eedc89d8001d1e098c1a1e23d12a9c755dff4
+  languageName: node
+  linkType: hard
+
 "strnum@npm:^1.0.5":
   version: 1.0.5
   resolution: "strnum@npm:1.0.5"
@@ -8566,10 +9057,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"time-zone@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "time-zone@npm:1.0.0"
+  checksum: e46f5a69b8c236dcd8e91e29d40d4e7a3495ed4f59888c3f84ce1d9678e20461421a6ba41233509d47dd94bc18f1a4377764838b21b584663f942b3426dcbce8
+  languageName: node
+  linkType: hard
+
 "tiny-warning@npm:^1.0.2":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
+  languageName: node
+  linkType: hard
+
+"tinybench@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "tinybench@npm:2.5.0"
+  checksum: 284bb9428f197ec8b869c543181315e65e41ccfdad3c4b6c916bb1fdae1b5c6785661b0d90cf135b48d833b03cb84dc5357b2d33ec65a1f5971fae0ab2023821
   languageName: node
   linkType: hard
 
@@ -8580,10 +9085,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinypool@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "tinypool@npm:0.5.0"
+  checksum: 4e0dfd8f28666d541c1d92304222edc4613f05d74fe2243c8520d466a2cc6596011a7072c1c41a7de7522351b82fda07e8038198e8f43673d8d69401c5903f8c
+  languageName: node
+  linkType: hard
+
 "tinyspy@npm:^1.0.2":
   version: 1.1.1
   resolution: "tinyspy@npm:1.1.1"
   checksum: 4ea908fdfddb92044c4454193ec543f5980ced0bd25c5b3d240a94c1511e47e765ad39cd13ae6d3370fb730f62038eedc357f55e4e239416e126bc418f0eee79
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tinyspy@npm:2.1.0"
+  checksum: cb83c1f74a79dd5934018bad94f60a304a29d98a2d909ea45fc367f7b80b21b0a7d8135a2ce588deb2b3ba56c7c607258b2a03e6001d89e4d564f9a95cc6a81f
   languageName: node
   linkType: hard
 
@@ -8759,6 +9278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ufo@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "ufo@npm:1.1.2"
+  checksum: 83c940a6a23b6d4fc0cd116265bb5dcf88ab34a408ad9196e413270ca607a4781c09b547dc518f43caee128a096f20fe80b5a0e62b4bcc0a868619896106d048
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.0.2":
   version: 1.0.2
   resolution: "unbox-primitive@npm:1.0.2"
@@ -8907,6 +9433,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:0.31.1":
+  version: 0.31.1
+  resolution: "vite-node@npm:0.31.1"
+  dependencies:
+    cac: ^6.7.14
+    debug: ^4.3.4
+    mlly: ^1.2.0
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    vite: ^3.0.0 || ^4.0.0
+  bin:
+    vite-node: vite-node.mjs
+  checksum: f70ffa3f6dcb4937cdc99f59bf360d42de83c556ba9a19eb1c3504ef20db4c1d1afa644d9a8e63240e851c0c95773b64c526bdb3eb4794b5e941ddcd57124aa9
+  languageName: node
+  linkType: hard
+
 "vite@npm:^2.9.12 || ^3.0.0-0, vite@npm:^3.0.0":
   version: 3.2.5
   resolution: "vite@npm:3.2.5"
@@ -8945,7 +9487,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:0.22.1, vitest@npm:^0.22.1":
+"vite@npm:^3.0.0 || ^4.0.0":
+  version: 4.3.9
+  resolution: "vite@npm:4.3.9"
+  dependencies:
+    esbuild: ^0.17.5
+    fsevents: ~2.3.2
+    postcss: ^8.4.23
+    rollup: ^3.21.0
+  peerDependencies:
+    "@types/node": ">= 14"
+    less: "*"
+    sass: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 8c45a516278d1e0425fac00c0877336790f71484a851a318346a70e0d2aef9f3b9651deb2f9f002c791ceb920eda7d6a3cda753bdefd657321c99f448b02dd25
+  languageName: node
+  linkType: hard
+
+"vitest@npm:0.22.1":
   version: 0.22.1
   resolution: "vitest@npm:0.22.1"
   dependencies:
@@ -8981,6 +9560,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:^0.31.0":
+  version: 0.31.1
+  resolution: "vitest@npm:0.31.1"
+  dependencies:
+    "@types/chai": ^4.3.5
+    "@types/chai-subset": ^1.3.3
+    "@types/node": "*"
+    "@vitest/expect": 0.31.1
+    "@vitest/runner": 0.31.1
+    "@vitest/snapshot": 0.31.1
+    "@vitest/spy": 0.31.1
+    "@vitest/utils": 0.31.1
+    acorn: ^8.8.2
+    acorn-walk: ^8.2.0
+    cac: ^6.7.14
+    chai: ^4.3.7
+    concordance: ^5.0.4
+    debug: ^4.3.4
+    local-pkg: ^0.4.3
+    magic-string: ^0.30.0
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    std-env: ^3.3.2
+    strip-literal: ^1.0.1
+    tinybench: ^2.5.0
+    tinypool: ^0.5.0
+    vite: ^3.0.0 || ^4.0.0
+    vite-node: 0.31.1
+    why-is-node-running: ^2.2.2
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@vitest/browser": "*"
+    "@vitest/ui": "*"
+    happy-dom: "*"
+    jsdom: "*"
+    playwright: "*"
+    safaridriver: "*"
+    webdriverio: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    playwright:
+      optional: true
+    safaridriver:
+      optional: true
+    webdriverio:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: b3f64a36102edc5b8594c085da648c838c0d275c620bd3b780624f936903b9c06579d6ef137fe9859e468f16deb8f154a50f009093119f9adb8b60ff1b7597ee
+  languageName: node
+  linkType: hard
+
 "w3c-xmlserializer@npm:^4.0.0":
   version: 4.0.0
   resolution: "w3c-xmlserializer@npm:4.0.0"
@@ -9001,6 +9641,13 @@ __metadata:
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
   checksum: f05588567a2a76428515333eff87200fae6c83c3948a7482ebb109562971e77ef6dc49749afa58abb993391227c5697b3ecca52018793e0cb4620a48f10bd21b
+  languageName: node
+  linkType: hard
+
+"well-known-symbols@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "well-known-symbols@npm:2.0.0"
+  checksum: 4f54bbc3012371cb4d228f436891b8e7536d34ac61a57541890257e96788608e096231e0121ac24d08ef2f908b3eb2dc0adba35023eaeb2a7df655da91415402
   languageName: node
   linkType: hard
 
@@ -9087,6 +9734,18 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 1a5c563d3c1b52d5f893c8b61afe11abc3bab4afac492e8da5bde69d550de701cf9806235f20a47b5c8fa8a1d6a9135841de2596535e998027a54589000e66d1
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "why-is-node-running@npm:2.2.2"
+  dependencies:
+    siginfo: ^2.0.0
+    stackback: 0.0.2
+  bin:
+    why-is-node-running: cli.js
+  checksum: 50820428f6a82dfc3cbce661570bcae9b658723217359b6037b67e495255409b4c8bc7931745f5c175df71210450464517cab32b2f7458ac9c40b4925065200a
   languageName: node
   linkType: hard
 
@@ -9244,6 +9903,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "yocto-queue@npm:1.0.0"
+  checksum: 2cac84540f65c64ccc1683c267edce396b26b1e931aa429660aefac8fbe0188167b7aee815a3c22fa59a28a58d898d1a2b1825048f834d8d629f4c2a5d443801
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes the failing skeleton test which was caused by misunderstanding how the mocked provider works. I was trying to mock it as loading but the correct way to test loading is to render and write assertions without waiting. To test after loading, use await to wait for elements to appear in the DOM. 

Fixing this required removing a hack I had built into my renderWithProviders util that created a short sleep to skip the loading state. I had been specifically hacking my way around being in the loading state instead of correct using await findByX to wait for loading to be completed. This realization caused me to rewrite many things related to tests:

- Remove the sleep from renderWithProviders
- Remove async from renderWithProviders
- Update tests that were relying on that sleep to work without out using await findByX
- Update tests to remove as much use of waitFor as possible in favor of await findByX
- Update tests to use screen.<function> instead of destructuring off the return from render/renderWithProviders
- Update tests to use userEvent instead of fireEvent
- Update test setup to provide a setup user object to all tests through context