### PR TITLE
#91: Remove use of query selector and fix search field labels

### DIFF
--- a/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.jsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.jsx
@@ -33,7 +33,7 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
           <Label htmlFor="Title">Title</Label>
           <TextField
             id="Title"
-            data-testid="Title"
+            inputProps={{ "aria-label": "Title" }}
             fullWidth
             size="small"
             variant="outlined"
@@ -51,7 +51,7 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
           <Label htmlFor="Poster">Poster URL</Label>
           <TextField
             id="Poster"
-            data-testid="Poster"
+            inputProps={{ "aria-label": "Poster" }}
             fullWidth
             size="small"
             variant="outlined"
@@ -70,7 +70,7 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
           <Label htmlFor="Background">Background URL</Label>
           <TextField
             id="Background"
-            data-testid="Background"
+            inputProps={{ "aria-label": "Background" }}
             fullWidth
             size="small"
             variant="outlined"
@@ -89,7 +89,6 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
           <Label htmlFor="Year">Year</Label>
           <TextField
             id="Year"
-            data-testid="Year"
             fullWidth
             size="small"
             variant="outlined"
@@ -105,6 +104,7 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
               }
             }}
             inputProps={{
+              "aria-label": "Year",
               maxLength: 4,
             }}
             error={userErrors.includes("Year")}
@@ -116,7 +116,6 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
           <Label htmlFor="Runtime">Runtime</Label>
           <TextField
             id="Runtime"
-            data-testid="Runtime"
             fullWidth
             size="small"
             variant="outlined"
@@ -133,6 +132,7 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
               }
             }}
             inputProps={{
+              "aria-label": "Runtime",
               maxLength: 4,
             }}
             error={userErrors.includes("Runtime")}
@@ -147,7 +147,7 @@ const TabPanelManual = ({ tabId, hidden, onAddMovie }) => {
           <Label htmlFor="IMDBId">IMDB Id</Label>
           <TextField
             id="IMDBId"
-            data-testid="IMDBId"
+            inputProps={{ "aria-label": "IMDBId" }}
             fullWidth
             size="small"
             variant="outlined"

--- a/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.test.jsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.test.jsx
@@ -4,8 +4,6 @@ import { vi } from "vitest";
 import { sources } from "md4k-constants";
 import { genres } from "md4k-constants";
 
-// NOTE: I had to use data-testid with querySelector here because I cannot figure out how to get MUI
-// to allow a label that propogates down to the input without creating its own field label and overwriting the placeholder.
 describe("tab-panel-manual", () => {
   beforeEach((context) => {
     context.props = {
@@ -21,17 +19,14 @@ describe("tab-panel-manual", () => {
     render(<TabPanelManual {...props} />);
 
     // Title
-    expect(screen.getByTestId("Title")).toBeInTheDocument();
-    await user.type(
-      screen.getByTestId("Title").querySelector("input"),
-      "Batman"
-    );
+    expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Title"), "Batman");
     expect(screen.getByDisplayValue("Batman")).toBeInTheDocument();
 
     // Poster
-    expect(screen.getByTestId("Poster")).toBeInTheDocument();
+    expect(screen.getByLabelText("Poster")).toBeInTheDocument();
     await user.type(
-      screen.getByTestId("Poster").querySelector("input"),
+      screen.getByLabelText("Poster"),
       "https://www.test.com/poster.jpg"
     );
     expect(
@@ -39,9 +34,9 @@ describe("tab-panel-manual", () => {
     ).toBeInTheDocument();
 
     // Background
-    expect(screen.getByTestId("Background")).toBeInTheDocument();
+    expect(screen.getByLabelText("Background")).toBeInTheDocument();
     await user.type(
-      screen.getByTestId("Background").querySelector("input"),
+      screen.getByLabelText("Background"),
       "https://www.test.com/background.jpg"
     );
     expect(
@@ -49,24 +44,18 @@ describe("tab-panel-manual", () => {
     ).toBeInTheDocument();
 
     // Year
-    expect(screen.getByTestId("Year")).toBeInTheDocument();
-    await user.type(screen.getByTestId("Year").querySelector("input"), "2005");
+    expect(screen.getByLabelText("Year")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Year"), "2005");
     expect(screen.getByDisplayValue("2005")).toBeInTheDocument();
 
     // Runtime
-    expect(screen.getByTestId("Runtime")).toBeInTheDocument();
-    await user.type(
-      screen.getByTestId("Runtime").querySelector("input"),
-      "120"
-    );
+    expect(screen.getByLabelText("Runtime")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Runtime"), "120");
     expect(screen.getByDisplayValue("120")).toBeInTheDocument();
 
     // IMDB ID
-    expect(screen.getByTestId("IMDBId")).toBeInTheDocument();
-    await user.type(
-      screen.getByTestId("IMDBId").querySelector("input"),
-      "tt1234567"
-    );
+    expect(screen.getByLabelText("IMDBId")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("IMDBId"), "tt1234567");
     expect(screen.getByDisplayValue("tt1234567")).toBeInTheDocument();
 
     // Genre
@@ -111,11 +100,8 @@ describe("tab-panel-manual", () => {
   it("should handle runtime input as minutes", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
-    await user.type(
-      screen.getByTestId("Runtime").querySelector("input"),
-      "120"
-    );
+    await user.type(screen.getByLabelText("Title"), "Test");
+    await user.type(screen.getByLabelText("Runtime"), "120");
 
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).toHaveBeenCalledWith(
@@ -128,11 +114,8 @@ describe("tab-panel-manual", () => {
   it("should handle runtime input as hh:mm", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
-    await user.type(
-      screen.getByTestId("Runtime").querySelector("input"),
-      "2:00"
-    );
+    await user.type(screen.getByLabelText("Title"), "Test");
+    await user.type(screen.getByLabelText("Runtime"), "2:00");
 
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).toHaveBeenCalledWith(
@@ -153,11 +136,8 @@ describe("tab-panel-manual", () => {
   it("should validate poster", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
-    await user.type(
-      screen.getByTestId("Poster").querySelector("input"),
-      "something invalid"
-    );
+    await user.type(screen.getByLabelText("Title"), "Test");
+    await user.type(screen.getByLabelText("Poster"), "something invalid");
 
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();
@@ -167,11 +147,8 @@ describe("tab-panel-manual", () => {
   it("should validate background", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
-    await user.type(
-      screen.getByTestId("Background").querySelector("input"),
-      "something invalid"
-    );
+    await user.type(screen.getByLabelText("Title"), "Test");
+    await user.type(screen.getByLabelText("Background"), "something invalid");
 
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();
@@ -181,8 +158,8 @@ describe("tab-panel-manual", () => {
   it("should validate year", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
-    await user.type(screen.getByTestId("Year").querySelector("input"), "100");
+    await user.type(screen.getByLabelText("Title"), "Test");
+    await user.type(screen.getByLabelText("Year"), "100");
 
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();
@@ -192,28 +169,25 @@ describe("tab-panel-manual", () => {
   it("should validate runtime", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
+    await user.type(screen.getByLabelText("Title"), "Test");
 
     // Incorrect colon
-    await user.type(screen.getByTestId("Runtime").querySelector("input"), ":0");
+    await user.type(screen.getByLabelText("Runtime"), ":0");
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();
     expect(screen.getByText(/Runtime must be/)).toBeInTheDocument();
 
     // Incorrect digits (too long)
-    await user.clear(screen.getByTestId("Runtime").querySelector("input"));
-    await user.type(
-      screen.getByTestId("Runtime").querySelector("input"),
-      "1000"
-    );
+    await user.clear(screen.getByLabelText("Runtime"));
+    await user.type(screen.getByLabelText("Runtime"), "1000");
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();
     expect(screen.getByText(/Runtime must be/)).toBeInTheDocument();
 
     // Incorrect digits (too short)
-    await user.clear(screen.getByTestId("Runtime").querySelector("input"));
-    await user.type(screen.getByTestId("Runtime").querySelector("input"), "1");
-    console.log(screen.getByTestId("Runtime").querySelector("input"));
+    await user.clear(screen.getByLabelText("Runtime"));
+    await user.type(screen.getByLabelText("Runtime"), "1");
+    console.log(screen.getByLabelText("Runtime"));
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();
     expect(screen.getByText(/Runtime must be/)).toBeInTheDocument();
@@ -222,11 +196,8 @@ describe("tab-panel-manual", () => {
   it("should validate imdb id", async ({ props, user }) => {
     render(<TabPanelManual {...props} />);
 
-    await user.type(screen.getByTestId("Title").querySelector("input"), "Test");
-    await user.type(
-      screen.getByTestId("IMDBId").querySelector("input"),
-      "12345"
-    );
+    await user.type(screen.getByLabelText("Title"), "Test");
+    await user.type(screen.getByLabelText("IMDBId"), "12345");
 
     await user.click(screen.getByRole("button", { name: "Add Movie" }));
     expect(props.onAddMovie).not.toHaveBeenCalled();

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.jsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.jsx
@@ -107,7 +107,7 @@ const TabPanelSearch = ({ tabId, hidden, onAddMovie }) => {
         <SearchLayout $shadow={!visible}>
           <SearchInput>
             <TextField
-              label="Search"
+              inputProps={{ "aria-label": "Search" }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
@@ -139,7 +139,7 @@ const TabPanelSearch = ({ tabId, hidden, onAddMovie }) => {
             />
 
             <TextField
-              label="Year"
+              inputProps={{ "aria-label": "Year" }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.test.jsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.test.jsx
@@ -158,7 +158,7 @@ describe("tab-panel-search", () => {
     });
 
     await user.type(screen.getByLabelText(/Search/), "Batman");
-    expect(await screen.findByDisplayValue("Batman")).toBeInTheDocument();
+    console.log(screen.debug(screen.getByLabelText(/Search/)))
 
     expect(await screen.findByLabelText("Search Results")).toBeInTheDocument();
     for (var i = 0; i < 10; i++) {


### PR DESCRIPTION
When the new add screen was built, I used a query selector to get to the input fields because I couldn't figure out how to assign a label to an MUI textfield without also overwriting the placeholder and displaying the label above the field. I figured out how to do this later. In the same feature, but on the search screen, I used labels on the fields which worked for the tests but I didn't notice how they affected the UI. This PR also fixes that up using the same solution.