### PR TITLE
#15: Update react-day-picker version

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "mdi-material-ui": "^7.6.0",
     "omit-deep-lodash": "^1.1.7",
     "react": "^18.2.0",
-    "react-day-picker": "8.0.0-beta.29",
+    "react-day-picker": "8.8.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "6.10.0",
     "react-slick": "^0.29.0",

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.jsx
@@ -1,4 +1,4 @@
-import "react-day-picker/style.css";
+import "react-day-picker/dist/style.css";
 
 import { useState } from "react";
 import { Drawer } from "@mui/material";
@@ -50,6 +50,7 @@ const DatePicker = ({
         }}
         defaultMonth={defaultDate}
         defaultSelected={defaultDate}
+        selected={day}
         disabled={{
           after: new Date(),
         }}
@@ -83,6 +84,7 @@ const DatePicker = ({
       open={true}
       ModalProps={{ hideBackdrop: true }}
       PaperProps={{ sx: [DrawerPaper] }}
+      data-testid="datePickerDrawer"
     >
       <Title>{title}</Title>
       {picker}

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.jsx
@@ -19,7 +19,7 @@ describe("date-picker", () => {
   }) => {
     renderWithProviders(<DatePicker {...props} />);
 
-    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("datePickerDrawer")).not.toBeInTheDocument();
     expect(screen.getByTestId("datePicker")).toBeInTheDocument();
   });
 
@@ -28,7 +28,7 @@ describe("date-picker", () => {
   }) => {
     renderWithProviders(<DatePicker {...props} useDrawer />);
 
-    expect(screen.queryByRole("presentation")).toBeInTheDocument();
+    expect(screen.queryByTestId("datePickerDrawer")).toBeInTheDocument();
     expect(screen.getByTestId("datePicker")).toBeInTheDocument();
   });
 
@@ -47,31 +47,29 @@ describe("date-picker", () => {
   it("should set the default date", ({ props }) => {
     renderWithProviders(<DatePicker {...props} />);
     expect(screen.getByText("January 2022")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "2nd January (Sunday)" })
-    ).toHaveClass("rdp-day_selected");
+    expect(screen.getByRole("gridcell", { name: "2" })).toHaveClass(
+      "rdp-day_selected"
+    );
   });
 
   it("should call onChange when changing the date", async ({ props, user }) => {
     renderWithProviders(<DatePicker {...props} />);
 
-    expect(
-      screen.getByRole("button", { name: "2nd January (Sunday)" })
-    ).toHaveClass("rdp-day_selected");
-
-    await user.click(
-      screen.getByRole("button", { name: "1st January (Saturday)" })
+    expect(screen.getByRole("gridcell", { name: "2" })).toHaveClass(
+      "rdp-day_selected"
     );
+
+    await user.click(screen.getByRole("gridcell", { name: "1" }));
 
     expect(props.onChange).toHaveBeenCalled();
 
-    expect(
-      screen.getByRole("button", { name: "2nd January (Sunday)" })
-    ).not.toHaveClass("rdp-day_selected");
+    expect(screen.getByRole("gridcell", { name: "2" })).not.toHaveClass(
+      "rdp-day_selected"
+    );
 
-    expect(
-      screen.getByRole("button", { name: "1st January (Saturday)" })
-    ).toHaveClass("rdp-day_selected");
+    expect(screen.getByRole("gridcell", { name: "1" })).toHaveClass(
+      "rdp-day_selected"
+    );
   });
 
   it("should call onDelete", async ({ props, user }) => {

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.jsx
@@ -143,7 +143,7 @@ describe("watched-movie", () => {
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("datePickerDrawer")).not.toBeInTheDocument();
   });
 
   it("should show the date picker in a drawer at small size", async ({
@@ -161,10 +161,10 @@ describe("watched-movie", () => {
 
     await user.click(screen.getByLabelText("Test Movie"));
 
-    expect(await screen.findByRole("presentation")).toBeInTheDocument();
+    expect(await screen.findByTestId("datePickerDrawer")).toBeInTheDocument();
 
     expect(
-      within(screen.getByRole("presentation")).getByTestId("datePicker")
+      within(screen.getByTestId("datePickerDrawer")).getByTestId("datePicker")
     ).toBeInTheDocument();
   });
 
@@ -177,7 +177,7 @@ describe("watched-movie", () => {
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /10th/ }));
+    await user.click(screen.getByRole("gridcell", { name: "10" }));
 
     await user.click(screen.getByTestId("CalendarCheckIcon"));
 
@@ -200,7 +200,7 @@ describe("watched-movie", () => {
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /10th/ }));
+    await user.click(screen.getByRole("gridcell", { name: "10" }));
 
     await user.click(screen.getByTestId("CloseIcon"));
 
@@ -234,7 +234,7 @@ describe("watched-movie", () => {
 
     expect(await screen.findByTestId("datePicker")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /10th/ }));
+    await user.click(screen.getByRole("gridcell", { name: "10" }));
 
     await user.click(screen.getByTestId("DeleteIcon"));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7062,7 +7062,7 @@ __metadata:
     mdi-material-ui: ^7.6.0
     omit-deep-lodash: ^1.1.7
     react: ^18.2.0
-    react-day-picker: 8.0.0-beta.29
+    react-day-picker: 8.8.0
     react-dom: ^18.2.0
     react-router-dom: 6.10.0
     react-slick: ^0.29.0
@@ -8061,13 +8061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-day-picker@npm:8.0.0-beta.29":
-  version: 8.0.0-beta.29
-  resolution: "react-day-picker@npm:8.0.0-beta.29"
+"react-day-picker@npm:8.8.0":
+  version: 8.8.0
+  resolution: "react-day-picker@npm:8.8.0"
   peerDependencies:
-    date-fns: ^2.10.0
-    react: ^16.8.0 || ^17.0.0
-  checksum: d9db7ddf57bb536e01f4c1a26dd2883a43862fb5608e6eba70230058c379c1a47ceead8f1d9e452be1d5025c2803090668745509d2c2b27a88726d60f1f35e89
+    date-fns: ^2.28.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: c104b4ae44bad44183f6a273327aa1d00d23afe6f3860f8335eea2d06c0f64ea015ea7438655c79a5024a8db259ba5fa9431dbf92f03889120d0c2c00a28117f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update react day picker version to 8.8.0. Migrate api and tests accordingly.