### PR TITLE
#112: add auto-updating of source, including tests.

### DIFF
--- a/packages/api/graphql/resolvers/mutation/utils/should-update-source.js
+++ b/packages/api/graphql/resolvers/mutation/utils/should-update-source.js
@@ -1,0 +1,39 @@
+import { sources } from "md4k-constants";
+
+const nonStreamingSources = [sources.NONE, sources.PLEX, sources.DVD];
+
+export const shouldUpdateSource = (currentSource, availableSources) => {
+  // Only update the source if:
+  //
+  // 1. The current source is a streaming source but no streaming sources are found.
+  // The source shouldn't change to None if it's a non-streaming source like DVD or PLEX
+  // ...those will never be found through the API and we don't want to change that source to None.
+  //
+  // 2. Available sources exist that are better than the current source:
+  // - There is no source
+  // - The source is a non-streaming source like DVD or PLEX
+  //
+  // It should NOT update the source when:
+  // - There's no streaming sources and the source is already NONE
+  // - There's already a streaming source like Netflix, but there are multiple available sources of which Netlfix is one.
+
+  if (
+    availableSources.length === 0 &&
+    !nonStreamingSources.includes(currentSource)
+  ) {
+    return sources.NONE;
+  }
+
+  if (
+    availableSources.length &&
+    (nonStreamingSources.includes(currentSource) ||
+      !availableSources.includes(currentSource))
+  ) {
+    return availableSources[0];
+  }
+
+  // We will get to this point if there are availableSources and the currentSource is a streaming source
+  // (ex: availableSources is [Disney, Netflix] and currentSource is Netflix). In this case, we don't want
+  // to change from one provider to another...it's valid but a bit pointless.
+  return null;
+};

--- a/packages/api/graphql/resolvers/mutation/utils/should-update-source.test.js
+++ b/packages/api/graphql/resolvers/mutation/utils/should-update-source.test.js
@@ -1,0 +1,55 @@
+import { sources } from "md4k-constants";
+import { shouldUpdateSource } from "./should-update-source";
+
+describe("should-update-source", () => {
+  it("should update the source to None when the current source is a streaming source and no available sources exist", () => {
+    expect(shouldUpdateSource(sources.NETFLIX, [])).toBe(sources.NONE);
+  });
+
+  it("should not update the source when the current source is a non-streaming source and no avaialble sources exist", () => {
+    expect(shouldUpdateSource(sources.DVD, [])).toBeNull();
+    expect(shouldUpdateSource(sources.PLEX, [])).toBeNull();
+  });
+
+  it("should not update the source when the current source is none and no avaialble sources exist", () => {
+    expect(shouldUpdateSource(sources.NONE, [])).toBeNull();
+  });
+
+  it("should udpate the source when the current source is none and an available source exists", () => {
+    expect(shouldUpdateSource(sources.NONE, [sources.NETFLIX])).toBe(
+      sources.NETFLIX
+    );
+  });
+
+  it("should udpate the source to the first available source when the current source is none and multiple available sources exist", () => {
+    expect(
+      shouldUpdateSource(sources.NONE, [sources.NETFLIX, sources.DISNEY_PLUS])
+    ).toBe(sources.NETFLIX);
+  });
+
+  it("should udpate the source to a streaming source when the current source is a non-streaming source", () => {
+    expect(shouldUpdateSource(sources.PLEX, [sources.NETFLIX])).toBe(
+      sources.NETFLIX
+    );
+
+    expect(shouldUpdateSource(sources.DVD, [sources.NETFLIX])).toBe(
+      sources.NETFLIX
+    );
+  });
+
+  it("should not udpate the source when the current source is a streaming source and exists within the available sources", () => {
+    expect(
+      shouldUpdateSource(sources.NETFLIX, [
+        sources.DISNEY_PLUS,
+        sources.PRIME_VIDEO,
+        sources.NETFLIX,
+      ])
+    ).toBeNull();
+  });
+
+  it("should update the source when the current streaming source is no longer valid but a different one exists.", () => {
+    expect(shouldUpdateSource(sources.NETFLIX, [sources.DISNEY_PLUS])).toBe(
+      sources.DISNEY_PLUS
+    );
+  });
+});

--- a/packages/api/graphql/resolvers/third-party-movie/third-party-provider.js
+++ b/packages/api/graphql/resolvers/third-party-movie/third-party-provider.js
@@ -1,14 +1,7 @@
 import lodash from "lodash";
-import { sources } from "md4k-constants";
+import { fromTMDBProvider } from "md4k-constants";
 
 const { first, isNil } = lodash;
-
-const fromTMDBProvider = {
-  "Disney Plus": sources.DISNEY_PLUS,
-  Netflix: sources.NETFLIX,
-  "Amazon Prime Video": sources.PRIME_VIDEO,
-  "Apple TV Plus": sources.APPLE_TV,
-};
 
 export const thirdPartyProvider = async ({ imdbID }, _, { dataSources }) => {
   // Look up the TMDB data using the imdbID.

--- a/packages/api/graphql/resolvers/third-party-movie/utils/to-tmdb-image-url.test.js
+++ b/packages/api/graphql/resolvers/third-party-movie/utils/to-tmdb-image-url.test.js
@@ -1,0 +1,19 @@
+import { toTMDBImageUrl } from "./to-tmdb-image-url";
+
+describe("toTMDBImageUrl", () => {
+  it("should add the path with default image size", () => {
+    expect(toTMDBImageUrl("/test/1/2/3/image.jpg")).toBe(
+      "http://image.tmdb.org/t/p/original/test/1/2/3/image.jpg"
+    );
+  });
+
+  it("should add the path with a provided image size", () => {
+    expect(toTMDBImageUrl("/test/1/2/3/image.jpg", "w300")).toBe(
+      "http://image.tmdb.org/t/p/w300/test/1/2/3/image.jpg"
+    );
+  });
+
+  it("should return null when no path is provided", () => {
+    expect(toTMDBImageUrl()).toBeNull();
+  });
+});

--- a/packages/api/graphql/resolvers/utils/to-subscribed-sources.js
+++ b/packages/api/graphql/resolvers/utils/to-subscribed-sources.js
@@ -1,0 +1,9 @@
+import lodash from "lodash";
+import { fromTMDBProvider } from "md4k-constants";
+
+const { isNil } = lodash;
+
+export const toSubscribedSources = (providerData) =>
+  (providerData?.results?.CA?.flatrate ?? [])
+    .map(({ provider_name }) => fromTMDBProvider[provider_name])
+    .filter((provider_name) => !isNil(provider_name));

--- a/packages/api/graphql/resolvers/utils/to-subscribed-sources.test.js
+++ b/packages/api/graphql/resolvers/utils/to-subscribed-sources.test.js
@@ -1,0 +1,62 @@
+import { sources } from "md4k-constants";
+import { toSubscribedSources } from "./to-subscribed-sources";
+
+describe("toSubscribedSources", () => {
+  it("should return a list of sources", () => {
+    expect(
+      toSubscribedSources({
+        results: {
+          CA: {
+            flatrate: [
+              { provider_name: "Netflix" },
+              { provider_name: "Disney Plus" },
+            ],
+          },
+        },
+      })
+    ).toEqual([sources.NETFLIX, sources.DISNEY_PLUS]);
+  });
+
+  it("should filter out sources that aren't subscribed", () => {
+    expect(
+      toSubscribedSources({
+        results: {
+          CA: {
+            flatrate: [
+              { provider_name: "Netflix" },
+              { provider_name: "SOME OTHER SERVICE" },
+              { provider_name: "Disney Plus" },
+              { provider_name: "ANOTHER SERVICE" },
+            ],
+          },
+        },
+      })
+    ).toEqual([sources.NETFLIX, sources.DISNEY_PLUS]);
+  });
+
+  it("should handle missing flatrate", () => {
+    expect(
+      toSubscribedSources({
+        results: {
+          CA: {},
+        },
+      })
+    ).toEqual([]);
+  });
+
+  it("should handle missing CA", () => {
+    expect(
+      toSubscribedSources({
+        results: {},
+      })
+    ).toEqual([]);
+  });
+
+  it("should handle missing results", () => {
+    expect(toSubscribedSources({})).toEqual([]);
+  });
+
+  it("should handle missing provider data", () => {
+    expect(toSubscribedSources(undefined)).toEqual([]);
+  });
+});

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.jsx
@@ -3,6 +3,7 @@ import Movie from "./movie";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../../../test-utils/render-with-providers";
 import { Globals } from "react-spring";
+import { UPDATE_MOVIE } from "../../../../../../../../graphql/mutations/update-movie";
 
 Globals.assign({
   skipAnimation: true,
@@ -22,6 +23,30 @@ vi.mock("../../../../../full-detail-modal/full-detail-modal", () => ({
     </div>
   ),
 }));
+
+const UPDATE_MOVIE_MOCK = {
+  request: {
+    query: UPDATE_MOVIE,
+    variables: {
+      movieId: "8502fd8b-165e-4239-965f-b46f8d523829",
+      list: "saturday",
+    },
+  },
+  newData: vi.fn(() => ({
+    data: {
+      updateMovie: {
+        id: "8502fd8b-165e-4239-965f-b46f8d523829",
+        source: 1,
+        ratings: {
+          id: "8502fd8b-165e-4239-965f-b46f8d523829",
+          IMDB: "79%",
+          ROTTEN_TOMATOES: "84%",
+          METACRITIC: "68%",
+        },
+      },
+    },
+  })),
+};
 
 describe("movie", () => {
   beforeEach((context) => {
@@ -93,7 +118,7 @@ describe("movie", () => {
     props,
     user,
   }) => {
-    renderWithProviders(<Movie {...props} />);
+    renderWithProviders(<Movie {...props} />, { mocks: [UPDATE_MOVIE_MOCK] });
 
     await user.hover(screen.getByTestId("listItem"));
     await waitFor(() => {

--- a/packages/web/src/graphql/mutations/update-movie.js
+++ b/packages/web/src/graphql/mutations/update-movie.js
@@ -2,28 +2,17 @@ import { gql, useMutation } from "@apollo/client";
 import { isToday, isValid, parseISO } from "date-fns";
 import { useEffect } from "react";
 
-const UPDATE_MOVIE = gql`
+export const UPDATE_MOVIE = gql`
   mutation UpdateMovie($movieId: ID!, $list: String!) {
     updateMovie(movieId: $movieId, list: $list) {
       id
-      title
-      list
-      runtime
       source
-      genre
-      year
-      poster
-      imdbID
-      locked
-      addedOn
-      watchedOn
       ratings {
         id
         IMDB
         ROTTEN_TOMATOES
         METACRITIC
       }
-      background
     }
   }
 `;

--- a/packages/web/src/graphql/mutations/update-movie.js
+++ b/packages/web/src/graphql/mutations/update-movie.js
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
-import { getYear } from "date-fns";
-import { useEffect, useState } from "react";
+import { isToday, isValid, parseISO } from "date-fns";
+import { useEffect } from "react";
 
 const UPDATE_MOVIE = gql`
   mutation UpdateMovie($movieId: ID!, $list: String!) {
@@ -30,20 +30,17 @@ const UPDATE_MOVIE = gql`
 
 export const useUpdateMovie = (movie, focused) => {
   const [updateMovie, status] = useMutation(UPDATE_MOVIE);
-  const [hasUpdated, setHasUpdated] = useState(false);
+  const lastUpdated = parseISO(localStorage.getItem(`lastUpdated_${movie.id}`));
 
   useEffect(() => {
     // A movie must have an imdbID to pull ratings.
-    // I only really care about updating ratings on newer movies as they actually change on platforms like
-    // rotten tomatoes and metacritic as more reviews come in.
-    // Ideally i'd only check on movies that are less than 6 months old but with only whole years, the best i can do
-    // is this year or last year (in case it is early in the current year).
+    // I only want to update each movie once a day to keep from spamming the 3rd party API's.
+    // If a movie has no local storage item (new, cleared storage), then the date is invalid.
+    // If it's an invalid date, let it go through.
     if (
-      !hasUpdated &&
-      focused &&
       movie.imdbID &&
-      movie.year &&
-      getYear(new Date()) - parseInt(movie.year) <= 1
+      (!isToday(lastUpdated) || !isValid(lastUpdated)) &&
+      focused
     ) {
       updateMovie({
         variables: {
@@ -57,9 +54,13 @@ export const useUpdateMovie = (movie, focused) => {
           },
         },
       });
-      setHasUpdated(true);
+
+      // Set this because we've sent a request.
+      // Regardless of whether it ends up updating or not, we don't want to keep spamming
+      // because the result is not going to change.
+      localStorage.setItem(`lastUpdated_${movie.id}`, new Date().toISOString());
     }
-  }, [focused, hasUpdated, movie, updateMovie]);
+  }, [focused, lastUpdated, movie, updateMovie]);
 
   return status;
 };

--- a/packages/web/src/test-utils/build-third-party-movie-mock.js
+++ b/packages/web/src/test-utils/build-third-party-movie-mock.js
@@ -2,7 +2,6 @@ export const buildThirdPartyMovieMock = (mockData = {}) => ({
   imdbID: "tt0258463",
   title: "The Bourne Identity",
   rated: "PG-13",
-  actors: ["Franka Potente", "Matt Damon", "Chris Cooper"],
   runtime: "7140",
   ratings: {
     id: "tt0258463",


### PR DESCRIPTION
Adds more functionality to the updateMovie mutation to include determining if the source needs to be changed. Started writing some tests in the API in this PR. The client has been updated to restrict checking more than once a day based on a local storage value per movie.