### PR TITLE
#68: Split watched movies from getMovies query

### DIFF
--- a/packages/web/src/components/app/components/watched/watched.error.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.error.test.jsx
@@ -2,7 +2,7 @@ import { Watched } from "./watched";
 import { within, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../test-utils/render-with-providers";
 import { vi } from "vitest";
-import { GET_MOVIES } from "../../../../graphql/queries";
+import {GET_WATCHED_MOVIES} from "../../../../graphql/queries/get-watched-movies.js";
 import { REMOVE_MOVIE } from "../../../../graphql/mutations";
 import { buildMovieMock } from "../../../../test-utils/build-movie-mock";
 
@@ -30,9 +30,9 @@ const REMOVE_MOVIE_ERROR_MOCK = {
   },
 };
 
-const GET_MOVIES_MOCK = {
+const GET_WATCHED_MOVIES_MOCK = {
   request: {
-    query: GET_MOVIES,
+    query: GET_WATCHED_MOVIES,
     variables: {
       list: "saturday",
     },
@@ -54,8 +54,7 @@ const GET_MOVIES_MOCK = {
 describe("watched - error", () => {
   it("should show the error", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
-      mocks: [REMOVE_MOVIE_ERROR_MOCK],
+      mocks: [GET_WATCHED_MOVIES_MOCK, REMOVE_MOVIE_ERROR_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();

--- a/packages/web/src/components/app/components/watched/watched.jsx
+++ b/packages/web/src/components/app/components/watched/watched.jsx
@@ -17,11 +17,13 @@ import {
 import { sortDirection } from "../../../../constants/sorts";
 import WatchedToolbar from "./components/watched-toolbar/watched-toolbar";
 import MovieRemove from "mdi-material-ui/MovieRemove";
+import {useGetWatchedMovies} from "../../../../graphql/queries/get-watched-movies.js";
 
 const INFINITE_LOAD_CHUNK_SIZE = 5;
 
 export const Watched = () => {
-  const { list, watchedMovies } = useAppContext();
+  const { list } = useAppContext();
+  const { watchedMovies } = useGetWatchedMovies(list);
   const [error, setError] = useState(null);
   const [deleteMovie, setDeleteMovie] = useState(null);
   const [editingMovie, setEditingMovie] = useState(null);
@@ -43,6 +45,7 @@ export const Watched = () => {
   useEffect(() => {
     const onScroll = ({ target: { documentElement } }) => {
       if (
+        watchedMovies?.length > 0 &&
         documentElement.scrollHeight - documentElement.scrollTop ===
         documentElement.clientHeight
       ) {

--- a/packages/web/src/components/app/components/watched/watched.test.jsx
+++ b/packages/web/src/components/app/components/watched/watched.test.jsx
@@ -2,7 +2,7 @@ import { Watched } from "./watched";
 import { waitFor, within, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../test-utils/render-with-providers";
 import { vi } from "vitest";
-import { GET_MOVIES } from "../../../../graphql/queries";
+import {GET_WATCHED_MOVIES} from "../../../../graphql/queries/get-watched-movies.js";
 import { buildMovieMock } from "../../../../test-utils/build-movie-mock";
 
 vi.mock("./components/watched-movie/watched-movie", () => ({
@@ -42,9 +42,9 @@ vi.mock("../../../../graphql/mutations", async () => {
   };
 });
 
-const GET_MOVIES_MOCK = {
+const GET_WATCHED_MOVIES_MOCK = {
   request: {
-    query: GET_MOVIES,
+    query: GET_WATCHED_MOVIES,
     variables: {
       list: "saturday",
     },
@@ -83,45 +83,44 @@ const GET_MOVIES_MOCK = {
           watchedOn: "2001-06-08T02:11:33.166Z",
         }),
       ],
-      movies: [],
     },
   },
 };
 
 describe("watched", () => {
   it("should render the toolbar", async () => {
-    renderWithProviders(<Watched />);
-    expect(await screen.findByText("2 movies watched")).toBeInTheDocument();
+    renderWithProviders(<Watched />, { mocks: [GET_WATCHED_MOVIES_MOCK] });
+    expect(await screen.findByText("6 movies watched")).toBeInTheDocument();
   });
 
   it("should search from the toolbar", async ({ user }) => {
-    renderWithProviders(<Watched />);
-    expect(await screen.findByText("2 movies watched")).toBeInTheDocument();
-    await user.type(screen.getByLabelText("Search"), "Always");
+    renderWithProviders(<Watched />, { mocks: [GET_WATCHED_MOVIES_MOCK] });
+    expect(await screen.findByText("6 movies watched")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Search"), "Iron");
     expect(
-      await screen.findByText("Showing 1 of 2 movies watched")
+      await screen.findByText("Showing 1 of 6 movies watched")
     ).toBeInTheDocument();
-    expect(await screen.findByText(/Always/)).toBeInTheDocument();
-    expect(screen.queryByText(/Tower Heist/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/Iron Man/)).toBeInTheDocument();
+    expect(screen.queryByText(/Fight Club/)).not.toBeInTheDocument();
   });
 
   it("should display the empty state when no movies are found by a search", async ({
     user,
   }) => {
-    renderWithProviders(<Watched />);
-    expect(await screen.findByText("2 movies watched")).toBeInTheDocument();
-    await user.type(screen.getByLabelText("Search"), "Bourne");
+    renderWithProviders(<Watched />, { mocks: [GET_WATCHED_MOVIES_MOCK] });
+    expect(await screen.findByText("6 movies watched")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Search"), "Apocalypse");
     expect(
-      await screen.findByText("Showing 0 of 2 movies watched")
+      await screen.findByText("Showing 0 of 6 movies watched")
     ).toBeInTheDocument();
-    expect(screen.queryByText(/Always/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Tower Heist/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Iron Man/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Fight Club/)).not.toBeInTheDocument();
     expect(screen.getByText(/No movies found/)).toBeInTheDocument();
   });
 
   it("should render the movies as watched movie items in reverse chronological order", async () => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
+      moviesMock: GET_WATCHED_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -146,7 +145,7 @@ describe("watched", () => {
     user,
   }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
+      moviesMock: GET_WATCHED_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -169,7 +168,7 @@ describe("watched", () => {
     user,
   }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
+      moviesMock: GET_WATCHED_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -203,7 +202,7 @@ describe("watched", () => {
 
   it("should enable editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
+      moviesMock: GET_WATCHED_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -219,7 +218,7 @@ describe("watched", () => {
 
   it("should save the movie and disable editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
+      moviesMock: GET_WATCHED_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -258,7 +257,7 @@ describe("watched", () => {
 
   it("should cancel editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_MOVIES_MOCK,
+      moviesMock: GET_WATCHED_MOVIES_MOCK,
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();

--- a/packages/web/src/context/app-context.jsx
+++ b/packages/web/src/context/app-context.jsx
@@ -7,7 +7,7 @@ const AppContext = createContext({});
 const AppProvider = ({ children }) => {
   const [list, _setList] = useState();
   const { lists } = useGetLists({ onCompleted: _setList });
-  const { movies, moviesById, watchedMovies } = useGetMovies(list);
+  const { movies, moviesById } = useGetMovies(list);
   const [toast, setToast] = useState(null);
   const [pick, setPick] = useState(null);
 
@@ -146,7 +146,6 @@ const AppProvider = ({ children }) => {
     setList,
     movies,
     moviesById,
-    watchedMovies,
     pick,
     setPick,
     clearPick,

--- a/packages/web/src/graphql/mutations/undo-mark-watched.js
+++ b/packages/web/src/graphql/mutations/undo-mark-watched.js
@@ -2,6 +2,7 @@ import { gql, useMutation } from "@apollo/client";
 import omit from "lodash/omit";
 import { omitTypename } from "../../utils/omit-typename";
 import { GET_MOVIES } from "../queries";
+import { GET_WATCHED_MOVIES } from "../queries/get-watched-movies.js";
 
 const GQL = gql`
   mutation UndoMarkWatched(
@@ -42,10 +43,28 @@ export const useUndoMarkWatched = ({ onCompleted }) => {
           query: GET_MOVIES,
           variables: { list: editMovie.list },
         },
-        ({ movies, watchedMovies }) => ({
+        ({ movies }) => ({
           movies: [...movies, editMovie],
-          watchedMovies: watchedMovies.filter(({ id }) => id !== editMovie.id),
         })
+      );
+
+      cache.updateQuery(
+        {
+          query: GET_WATCHED_MOVIES,
+          variables: { list: editMovie.list },
+        },
+
+        // Only update the cache for watched movies if its been called at least once before.
+        // It will return null for the cache read response if it has not been called.
+        (response) => {
+          if (response?.watchedMovies) {
+            return {
+              watchedMovies: response.watchedMovies.filter(
+                ({ id }) => id !== editMovie.id
+              ),
+            };
+          }
+        }
       );
     },
   });

--- a/packages/web/src/graphql/queries/get-movies.js
+++ b/packages/web/src/graphql/queries/get-movies.js
@@ -24,15 +24,6 @@ export const GET_MOVIES = gql`
       fiveStarRating
       background
     }
-    watchedMovies(list: $list) {
-      id
-      title
-      list
-      poster
-      imdbID
-      watchedOn
-      background
-    }
   }
 `;
 

--- a/packages/web/src/graphql/queries/get-watched-movies.js
+++ b/packages/web/src/graphql/queries/get-watched-movies.js
@@ -1,0 +1,27 @@
+import { gql, useQuery } from "@apollo/client";
+
+export const GET_WATCHED_MOVIES = gql`
+  query GetWatchedMovies($list: String!) {
+    watchedMovies(list: $list) {
+      id
+      title
+      list
+      poster
+      imdbID
+      watchedOn
+      background
+    }
+  }
+`;
+
+export const useGetWatchedMovies = (list) => {
+  const { data, ...rest } = useQuery(GET_WATCHED_MOVIES, {
+    skip: !list,
+    variables: { list: list?.id }
+  });
+
+  return {
+    ...data,
+    ...rest,
+  };
+};


### PR DESCRIPTION
Removes fetching of the watched movies from the initial query for all movies and also removes watched movies from the context. The watched movies are now only fetched when you go that screen.