### PR TITLE
#134: Load images using requestIdleCallback when out of view

### DIFF
--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.jsx
@@ -86,7 +86,7 @@ const Movie = ({ movie, onEditMovie, onMarkWatched, onDeleteMovie }) => {
         data-testid={"listItem"}
       >
         <MoviePosterContainer>
-          <MoviePoster movie={movie} />
+          <MoviePoster movie={movie} delayLoadingWhenNotInView />
         </MoviePosterContainer>
 
         <MovieDetailPositioner
@@ -99,7 +99,12 @@ const Movie = ({ movie, onEditMovie, onMarkWatched, onDeleteMovie }) => {
         >
           <MovieDetail style={posterSpring}>
             <OverflowWrapper>
-              <MoviePoster movie={movie} height={375} variant="zoom" />
+              <MoviePoster
+                movie={movie}
+                height={375}
+                variant="zoom"
+                delayLoadingWhenNotInView
+              />
 
               <InfoLayout>
                 <StarRatingLayout

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.test.jsx
@@ -34,6 +34,7 @@ describe("movie-poster", () => {
         },
         background: "http://image.tmdb.org/t/2.jpg",
       },
+      delayLoadingWhenNotInView: true,
       onClick: vi.fn(),
     };
   });
@@ -63,6 +64,14 @@ describe("movie-poster", () => {
 
     expect(screen.getByTestId("poster")).toHaveStyle({
       "background-image": "",
+    });
+    expect(screen.getByText(/Bourne/)).toBeInTheDocument();
+  });
+
+  it("should render the poster when not delayed", ({ props }) => {
+    render(<MoviePoster {...props} delayLoadingWhenNotInView={false} />);
+    expect(screen.getByTestId("poster")).toHaveStyle({
+      "background-image": `url(${props.movie.poster})`,
     });
     expect(screen.getByText(/Bourne/)).toBeInTheDocument();
   });

--- a/packages/web/vitest-setup.js
+++ b/packages/web/vitest-setup.js
@@ -30,6 +30,9 @@ beforeAll(() => {
   vi.mock("rooks/dist/esm/hooks/useInViewRef", () => ({
     useInViewRef: vi.fn().mockReturnValue([null, true]),
   }));
+
+  // Stub the requestIdleCallback
+  vi.stubGlobal("requestIdleCallback", vi.fn());
 });
 
 beforeEach((context) => {


### PR DESCRIPTION
Adds an opt-in flag that loads the poster image during an idle callback if offscreen