### PR TITLE
#138: Add sorting by Source value

### DIFF
--- a/packages/web/src/components/app/components/full-detail/full-detail.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.jsx
@@ -5,6 +5,7 @@ import ChevronLeft from "@mui/icons-material/ChevronLeft";
 import ChevronRight from "@mui/icons-material/ChevronRight";
 import { useSpring } from "react-spring";
 import CloseThick from "mdi-material-ui/CloseThick";
+import isNil from "lodash/isNil";
 
 import { formatRuntime } from "../../../../utils/format-runtime";
 import { searchStreaming, searchTMDB } from "../../../../utils/search";
@@ -80,7 +81,12 @@ const FullDetail = ({
     window.open(searchTMDB(movie.title), "moviedb");
   }, [movie]);
 
-  const source = movie.source || data.source || sources.NONE;
+  const source = !isNil(movie.source)
+    ? movie.source
+    : !isNil(data.source)
+    ? data.source
+    : sources.NONE;
+
   const canStream = ![sources.DVD, sources.NONE].includes(source);
 
   const backdrop = useMemo(

--- a/packages/web/src/components/app/components/full-detail/full-detail.test.jsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.test.jsx
@@ -25,7 +25,7 @@ const GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK = {
   },
   result: {
     data: {
-      thirdPartyMovie: buildThirdPartyMovieMock(),
+      thirdPartyMovie: buildThirdPartyMovieMock({ source: 7 }),
     },
   },
 };
@@ -66,6 +66,8 @@ describe("full-detail", () => {
       id: "saturday",
       label: "Saturday Night",
     };
+
+    window.open = vi.fn();
   });
 
   it("should render the movie details", async ({ props }) => {
@@ -109,8 +111,6 @@ describe("full-detail", () => {
     props,
     user,
   }) => {
-    window.open = vi.fn();
-
     renderWithProviders(<FullDetail {...props} />, {
       mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
     });
@@ -237,6 +237,76 @@ describe("full-detail", () => {
       expect.stringMatching(/netflix.*Bourne/),
       "movieView"
     );
+  });
+
+  it("should use the movie source when available", async ({ props }) => {
+    renderWithProviders(<FullDetail {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
+
+    expect(await screen.findByAltText(sourceLabels[1])).toBeInTheDocument();
+  });
+
+  it("should use the movie source when available and 0 (falsy)", async ({
+    props,
+  }) => {
+    renderWithProviders(
+      <FullDetail {...props} movie={{ ...props.movie, source: 0 }} />,
+      {
+        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+      }
+    );
+
+    expect(await screen.findByAltText(sourceLabels[0])).toBeInTheDocument();
+  });
+
+  it("should use the third party data source when available and movie source is not", async ({
+    props,
+  }) => {
+    renderWithProviders(
+      <FullDetail {...props} movie={{ ...props.movie, source: undefined }} />,
+      {
+        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+      }
+    );
+
+    expect(await screen.findByAltText(sourceLabels[7])).toBeInTheDocument();
+  });
+
+  it("should use the third party data source when it is 0 and movie source is not", async ({
+    props,
+  }) => {
+    renderWithProviders(
+      <FullDetail {...props} movie={{ ...props.movie, source: undefined }} />,
+      {
+        mocks: [
+          {
+            ...GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
+            result: { data: buildThirdPartyMovieMock({ source: 0 }) },
+          },
+        ],
+      }
+    );
+
+    expect(await screen.findByAltText(sourceLabels[0])).toBeInTheDocument();
+  });
+
+  it("should use source.NONE when both the movie and the third party data have no source", async ({
+    props,
+  }) => {
+    renderWithProviders(
+      <FullDetail {...props} movie={{ ...props.movie, source: undefined }} />,
+      {
+        mocks: [
+          {
+            ...GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK,
+            result: { data: buildThirdPartyMovieMock({ source: undefined }) },
+          },
+        ],
+      }
+    );
+
+    expect(await screen.findByAltText(sourceLabels[0])).toBeInTheDocument();
   });
 
   it("should not stream when the source logo is DVD", async ({

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.jsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.jsx
@@ -39,22 +39,26 @@ const SortNav = () => {
 
   return (
     <SortNavList>
-      {Object.values(sort).map((key) => (
-        <SortNavListItem
-          key={key}
-          data-active={key === order}
-          data-sort={key === order ? direction : undefined}
-          sx={[key === order && sortNavSelectedItem]}
-          onClick={() => {
-            navigate(`/list/${resolveOrder(key).join("/")}`);
-          }}
-        >
-          {t(`list:sort.${key}`)}
-          {key === order && (
-            <SortOrderIcon fontSize="small" style={sortOrderIcon} />
-          )}
-        </SortNavListItem>
-      ))}
+      {Object.values(sort)
+        // For the time being, remove the genre sort.
+        // There are too many sorts to fit at mobile size.
+        .filter((key) => key !== sort.GENRE)
+        .map((key) => (
+          <SortNavListItem
+            key={key}
+            data-active={key === order}
+            data-sort={key === order ? direction : undefined}
+            sx={[key === order && sortNavSelectedItem]}
+            onClick={() => {
+              navigate(`/list/${resolveOrder(key).join("/")}`);
+            }}
+          >
+            {t(`list:sort.${key}`)}
+            {key === order && (
+              <SortOrderIcon fontSize="small" style={sortOrderIcon} />
+            )}
+          </SortNavListItem>
+        ))}
     </SortNavList>
   );
 };

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.styles.js
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.styles.js
@@ -31,10 +31,17 @@ export const SortNavListItem = styled("li")(
   })
 );
 
-export const sortNavSelectedItem = ({ palette }) => ({
+export const sortNavSelectedItem = ({ breakpoints, palette }) => ({
   fontSize: "1rem",
   color: "initial",
   borderBottom: `1px solid ${palette.accent}`,
+
+  // In the current nav, there is a tiny issue with the runtime item (because its the the longest).
+  // When active, it takes up just a bit too much room at 375px and causes the direction arrow to line break.
+  // This just fixes that and maybe be able to be removed in the future if the nav items change.
+  [breakpoints.down(414)]: {
+    fontSize: "0.95rem",
+  },
 });
 
 export const sortOrderIcon = {

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.jsx
@@ -33,6 +33,7 @@ const SortedRating = ({ movies, ...handlers }) => {
         title: <FiveStarRating stars={stars} />,
         list,
         ariaLabel: t("list_grid:sorted_rating.stars", { stars }),
+        stars,
       })
     );
 

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.jsx
@@ -1,0 +1,61 @@
+import orderBy from "lodash/orderBy";
+import flow from "lodash/fp/flow";
+import groupBy from "lodash/fp/groupBy";
+import mapValues from "lodash/fp/mapValues";
+import thru from "lodash/fp/thru";
+import toPairs from "lodash/fp/toPairs";
+import { useMemo } from "react";
+import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
+import MovieSection from "../movie-section/movie-section";
+import { sort, sortDirection } from "../../../../../../../../constants/sorts";
+import { useI18n } from "../../../../../../../../hooks/use-i18n";
+import listGridStrings from "../../i18n/i18n";
+import {
+  sourceLabels,
+  sourceLogosLarge,
+} from "../../../../../../../../constants/sources";
+
+const SortedSource = ({ movies, ...handlers }) => {
+  const { t } = useI18n(listGridStrings);
+  const direction = useSortDirection();
+
+  const bySource = useMemo(() => {
+    const partitionMovies = flow(
+      groupBy((movie) => movie.source ?? 0),
+      mapValues((movies) => orderBy(movies, [sort.TITLE], [sortDirection.ASC])),
+      toPairs,
+      // Move the first source (0: none) to the end
+      thru((arr) => [...arr.slice(1), arr[0]])
+    );
+
+    return partitionMovies(movies);
+  }, [movies]);
+
+  const sections = useMemo(() => {
+    const sectionDescriptors = bySource.map(([source, list]) => ({
+      title: (
+        <img
+          src={sourceLogosLarge[source]}
+          width="120px"
+          alt={sourceLabels[source]}
+        />
+      ),
+      list,
+      ariaLabel: t(`common:sources.${source ?? 0}`),
+      source,
+    }));
+    return direction === sortDirection.ASC
+      ? sectionDescriptors
+      : sectionDescriptors.reverse();
+  }, [direction, bySource, t]);
+
+  return (
+    <span data-testid={sort.SOURCE}>
+      {sections.map((props) => (
+        <MovieSection key={props.source} {...props} {...handlers} />
+      ))}
+    </span>
+  );
+};
+
+export default SortedSource;

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.test.jsx
@@ -1,0 +1,165 @@
+import { render, within, screen } from "@testing-library/react";
+import SortedSource from "./sorted-source";
+import { vi } from "vitest";
+
+const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
+  MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),
+}));
+
+vi.mock("../movie/movie", () => ({
+  default: ({ onEditMovie, onMarkWatched, onDeleteMovie, movie }) => (
+    <div aria-label="movieMock">
+      {movie.title}
+      <button onClick={() => onEditMovie(movie)}>Edit</button>
+      <button onClick={() => onMarkWatched(movie)}>Mark Watched</button>
+      <button onClick={() => onDeleteMovie(movie)}>Delete</button>
+    </div>
+  ),
+}));
+
+vi.mock("../../../../../../../../hooks/use-sort-direction", () => ({
+  useSortDirection: MOCK_USE_SORT_DIRECTION,
+}));
+
+describe("sorted-source", () => {
+  beforeEach((context) => {
+    context.props = {
+      movies: [
+        {
+          id: 0,
+          title: "Movie 1",
+          source: 0,
+        },
+        {
+          id: 1,
+          title: "Movie 2",
+          source: 1,
+        },
+        {
+          id: 2,
+          title: "Movie 3",
+          source: 2,
+        },
+        {
+          id: 3,
+          title: "Movie 4",
+          source: 3,
+        },
+      ],
+      onEditMovie: vi.fn(),
+      onMarkWatched: vi.fn(),
+      onDeleteMovie: vi.fn(),
+    };
+  });
+
+  it("should render correctly when the order is ASC", ({ props }) => {
+    render(<SortedSource {...props} />);
+
+    expect(
+      within(screen.getByTestId("source").childNodes[0]).getByAltText("Netflix")
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[0]).getByText("Movie 2")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("source").childNodes[1]).getByAltText(
+        "Prime Video"
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[1]).getByText("Movie 3")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("source").childNodes[2]).getByAltText(
+        "AppleTV+"
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[2]).getByText("Movie 4")
+    ).toBeInTheDocument();
+
+    // The "No Source" section should be moved to the end
+    expect(
+      within(screen.getByTestId("source").childNodes[3]).getByAltText("None")
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[3]).getByText("Movie 1")
+    ).toBeInTheDocument();
+  });
+
+  it("should render correctly when the order is DESC", ({ props }) => {
+    MOCK_USE_SORT_DIRECTION.mockReturnValue("desc");
+
+    render(<SortedSource {...props} />);
+
+    expect(
+      within(screen.getByTestId("source").childNodes[0]).getByAltText("None")
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[0]).getByText("Movie 1")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("source").childNodes[1]).getByAltText(
+        "AppleTV+"
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[1]).getByText("Movie 4")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("source").childNodes[2]).getByAltText(
+        "Prime Video"
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[2]).getByText("Movie 3")
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("source").childNodes[3]).getByAltText("Netflix")
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("source").childNodes[3]).getByText("Movie 2")
+    ).toBeInTheDocument();
+  });
+
+  it("should call the edit handler", async ({ props, user }) => {
+    render(<SortedSource {...props} />);
+    await user.click(
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Edit",
+      })
+    );
+    expect(props.onEditMovie).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Movie 1" })
+    );
+  });
+
+  it("should call the mark watched handler", async ({ props, user }) => {
+    render(<SortedSource {...props} />);
+    await user.click(
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Mark Watched",
+      })
+    );
+    expect(props.onMarkWatched).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Movie 1" })
+    );
+  });
+
+  it("should call the delete handler", async ({ props, user }) => {
+    render(<SortedSource {...props} />);
+    await user.click(
+      within(screen.getByText("Movie 1")).getByRole("button", {
+        name: "Delete",
+      })
+    );
+    expect(props.onDeleteMovie).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Movie 1" })
+    );
+  });
+});

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.jsx
@@ -10,6 +10,7 @@ import SortedAdded from "./components/sorted-added/sorted-added";
 import SortedGenre from "./components/sorted-genre/sorted-genre";
 import { sort } from "../../../../../../constants/sorts";
 import SortedRating from "./components/sorted-rating/sorted-rating";
+import SortedSource from "./components/sorted-source/sorted-source";
 
 const ListGrid = ({ movies, onRemoveMovie, onMarkWatched, onEditMovie }) => {
   const [deleteMovie, setDeleteMovie] = useState(null);
@@ -73,6 +74,18 @@ const ListGrid = ({ movies, onRemoveMovie, onMarkWatched, onEditMovie }) => {
               path={`${sort.RATING}/:direction`}
               element={
                 <SortedRating
+                  movies={movies}
+                  onEditMovie={onEditMovie}
+                  onMarkWatched={onMarkWatched}
+                  onDeleteMovie={setDeleteMovie}
+                />
+              }
+            />
+
+            <Route
+              path={`${sort.SOURCE}/:direction`}
+              element={
+                <SortedSource
                   movies={movies}
                   onEditMovie={onEditMovie}
                   onMarkWatched={onMarkWatched}

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.jsx
@@ -50,11 +50,11 @@ describe("list-grid", () => {
     expect(screen.getByTestId("runtime")).toBeInTheDocument();
   });
 
-  it("should render the genre list", ({ props }) => {
+  it("should render the source list", ({ props }) => {
     renderWithProviders(<ListGrid {...props} />, {
-      route: "/genre/asc",
+      route: "/source/asc",
     });
-    expect(screen.getByTestId("genre")).toBeInTheDocument();
+    expect(screen.getByTestId("source")).toBeInTheDocument();
   });
 
   it("should render the empty list when there are no movies", ({ props }) => {

--- a/packages/web/src/components/app/components/list/i18n/resources/en.json
+++ b/packages/web/src/components/app/components/list/i18n/resources/en.json
@@ -9,7 +9,8 @@
     "title": "Title",
     "runtime": "Runtime",
     "genre": "Genre",
-    "rating": "Rating"
+    "rating": "Rating",
+    "source": "Source"
   },
   "pick": {
     "title": "Pick A Movie",

--- a/packages/web/src/constants/sorts.js
+++ b/packages/web/src/constants/sorts.js
@@ -4,6 +4,7 @@ export const sort = {
   RUNTIME: "runtime",
   GENRE: "genre",
   RATING: "rating",
+  SOURCE: "source",
 };
 
 export const sortDirection = {


### PR DESCRIPTION
Adds a new sort for Source type. The new sort means there are now too many to fit at a couple of breakpoints, particularly mobile size. Rather than try to build an alternative nav presentation at that size, I decided to just hide the Genre sort for now since it is the least used. I may revisit adding it back in the future. I also cleaned up a couple of small bugs here.