### PR TITLE
#140: add 5-star rating to update movie response

### DIFF
--- a/packages/web/src/graphql/mutations/update-movie.js
+++ b/packages/web/src/graphql/mutations/update-movie.js
@@ -13,6 +13,7 @@ export const UPDATE_MOVIE = gql`
         ROTTEN_TOMATOES
         METACRITIC
       }
+      fiveStarRating
     }
   }
 `;


### PR DESCRIPTION
Adds the missing 5-star rating to the update movie response which was causing the 5-star rating to become out of sync with the ratings.