### PR TITLE
#155: fix imports that are type only, clean up the configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,15 +10,28 @@
   ],
   "plugins": ["@typescript-eslint", "vitest", "testing-library"],
   "rules": {
-    "no-unused-vars": "error",
     "require-await": "error",
     "vitest/no-focused-tests": "error",
     "vitest/no-disabled-tests": "error",
     "vitest/no-duplicate-hooks": "error",
     "vitest/consistent-test-filename": "error",
     "vitest/consistent-test-it": "error",
-    "vitest/prefer-comparison-matcher": "error"
+    "vitest/prefer-comparison-matcher": "error",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      { "fixStyle": "inline-type-imports" }
+    ],
+    "@typescript-eslint/explicit-function-return-type": "off"
   },
+  "overrides": [
+    {
+      // enable the rule specifically for test files
+      "files": ["*.test.ts", "*.test.tsx"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": 0
+      }
+    }
+  ],
   "env": {
     "node": true,
     "jest": true

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -1,9 +1,9 @@
-import { ApolloServer, ExpressContext } from "apollo-server-express";
+import { ApolloServer, type ExpressContext } from "apollo-server-express";
 import {
   ApolloServerPluginDrainHttpServer,
   AuthenticationError,
 } from "apollo-server-core";
-import { Db, MongoClient } from "mongodb";
+import { type Db, MongoClient } from "mongodb";
 import http from "http";
 import express from "express";
 import cors from "cors";

--- a/packages/api/src/auth/validate.ts
+++ b/packages/api/src/auth/validate.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-import jwt, { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import jwt, { type JwtHeader, type JwtPayload, type SigningKeyCallback } from "jsonwebtoken";
 import jwksClient from "jwks-rsa";
 
 dotenv.config();

--- a/packages/api/src/graphql/datasources/omdb-datasource.ts
+++ b/packages/api/src/graphql/datasources/omdb-datasource.ts
@@ -1,9 +1,9 @@
-import { RESTDataSource, RequestOptions } from "apollo-datasource-rest";
+import { RESTDataSource, type RequestOptions } from "apollo-datasource-rest";
 import {
-  OMDBGetMovieResponse,
-  OMDBSearchResponse,
+  type OMDBGetMovieResponse,
+  type OMDBSearchResponse,
 } from "../types/omdb.types.js";
-import { Maybe } from "graphql/jsutils/Maybe.js";
+import { type Maybe } from "graphql/jsutils/Maybe.js";
 
 export class OMDBDataSource extends RESTDataSource {
   constructor() {

--- a/packages/api/src/graphql/datasources/tmdb-datasource.ts
+++ b/packages/api/src/graphql/datasources/tmdb-datasource.ts
@@ -1,9 +1,9 @@
-import { RESTDataSource, RequestOptions } from "apollo-datasource-rest";
+import { RESTDataSource, type RequestOptions } from "apollo-datasource-rest";
 import {
-  TMDBError,
-  TMDBFindResult,
-  TMDBMovieResult,
-  TMDBProviderResults,
+  type TMDBError,
+  type TMDBFindResult,
+  type TMDBMovieResult,
+  type TMDBProviderResults,
 } from "../types/tmdb.types.js";
 
 export class TMDBDataSource extends RESTDataSource {

--- a/packages/api/src/graphql/resolvers/index.ts
+++ b/packages/api/src/graphql/resolvers/index.ts
@@ -18,7 +18,7 @@ import {
   thirdPartyProvider,
   thirdPartyTrailer,
 } from "./third-party-movie/index.js";
-import { Resolvers } from "../../__generated__/graphql.js";
+import { type Resolvers } from "../../__generated__/graphql.js";
 
 export const resolvers: Resolvers = {
   Query: {

--- a/packages/api/src/graphql/resolvers/movie/five-star-rating.ts
+++ b/packages/api/src/graphql/resolvers/movie/five-star-rating.ts
@@ -1,4 +1,4 @@
-import { MovieResolvers } from "../../../__generated__/graphql.js";
+import { type MovieResolvers } from "../../../__generated__/graphql.js";
 import { toFiveStarRating } from "../utils/to-five-star-rating.js";
 
 export const fiveStarRating: MovieResolvers["fiveStarRating"] = ({ ratings }) =>

--- a/packages/api/src/graphql/resolvers/mutation/add-list.ts
+++ b/packages/api/src/graphql/resolvers/mutation/add-list.ts
@@ -1,7 +1,7 @@
 import { ApolloError } from "apollo-server-errors";
 import { errorCodes } from "md4k-constants";
 import { v4 as uuidv4 } from "uuid";
-import { MutationResolvers } from "../../../__generated__/graphql.js";
+import { type MutationResolvers } from "../../../__generated__/graphql.js";
 
 export const addList: MutationResolvers["addList"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/mutation/add-movie.ts
+++ b/packages/api/src/graphql/resolvers/mutation/add-movie.ts
@@ -1,7 +1,7 @@
 import { ApolloError } from "apollo-server-errors";
 import lodash from "lodash";
 import { Source, errorCodes } from "md4k-constants";
-import { MutationResolvers } from "../../../__generated__/graphql.js";
+import { type MutationResolvers } from "../../../__generated__/graphql.js";
 
 const { isNil } = lodash;
 

--- a/packages/api/src/graphql/resolvers/mutation/edit-movie.ts
+++ b/packages/api/src/graphql/resolvers/mutation/edit-movie.ts
@@ -1,5 +1,5 @@
-import { MutationResolvers } from "../../../__generated__/graphql.js";
-import { Movie } from "../../types/db.types.js";
+import { type MutationResolvers } from "../../../__generated__/graphql.js";
+import { type Movie } from "../../types/db.types.js";
 
 export const editMovie: MutationResolvers["editMovie"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/mutation/remove-movie.ts
+++ b/packages/api/src/graphql/resolvers/mutation/remove-movie.ts
@@ -1,4 +1,4 @@
-import { MutationResolvers } from "../../../__generated__/graphql.js";
+import { type MutationResolvers } from "../../../__generated__/graphql.js";
 
 export const removeMovie: MutationResolvers["removeMovie"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/mutation/update-movie.ts
+++ b/packages/api/src/graphql/resolvers/mutation/update-movie.ts
@@ -1,8 +1,8 @@
 import { convertOmdbRatings } from "../../../utils/convert-omdb-ratings.js";
 import { shouldUpdateSource } from "./utils/should-update-source.js";
 import { toSubscribedSources } from "../utils/to-subscribed-sources.js";
-import { MutationResolvers } from "../../../__generated__/graphql.js";
-import { Movie } from "../../types/db.types.js";
+import { type MutationResolvers } from "../../../__generated__/graphql.js";
+import { type Movie } from "../../types/db.types.js";
 
 export const updateMovie: MutationResolvers["updateMovie"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/query/lists.ts
+++ b/packages/api/src/graphql/resolvers/query/lists.ts
@@ -1,5 +1,5 @@
-import { QueryResolvers } from "../../../__generated__/graphql.js";
-import { List } from "../../types/db.types.js";
+import { type QueryResolvers } from "../../../__generated__/graphql.js";
+import { type List } from "../../types/db.types.js";
 
 export const lists: QueryResolvers["lists"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/query/movies.ts
+++ b/packages/api/src/graphql/resolvers/query/movies.ts
@@ -1,5 +1,5 @@
-import { QueryResolvers } from "../../../__generated__/graphql.js";
-import { Movie } from "../../types/db.types.js";
+import { type QueryResolvers } from "../../../__generated__/graphql.js";
+import { type Movie } from "../../types/db.types.js";
 
 export const movies: QueryResolvers["movies"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/query/search-by-title.ts
+++ b/packages/api/src/graphql/resolvers/query/search-by-title.ts
@@ -1,4 +1,4 @@
-import { QueryResolvers } from "../../../__generated__/graphql.js";
+import { type QueryResolvers } from "../../../__generated__/graphql.js";
 
 export const searchByTitle: QueryResolvers["searchByTitle"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/query/watched-movies.ts
+++ b/packages/api/src/graphql/resolvers/query/watched-movies.ts
@@ -1,5 +1,5 @@
-import { QueryResolvers } from "../../../__generated__/graphql.js";
-import { Movie } from "../../types/db.types.js";
+import { type QueryResolvers } from "../../../__generated__/graphql.js";
+import { type Movie } from "../../types/db.types.js";
 
 export const watchedMovies: QueryResolvers["watchedMovies"] = async (
   parent,

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-backdrop.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-backdrop.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 import { toTMDBImageUrl } from "./utils/to-tmdb-image-url.js";
 
 export const thirdPartyBackdrop: ThirdPartyMovieResolvers["backdrop"] = async (

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-backdrops.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-backdrops.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 import { toTMDBImageUrl } from "./utils/to-tmdb-image-url.js";
 
 export const thirdPartyBackdrops: ThirdPartyMovieResolvers["backdrops"] =

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-cast.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-cast.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 import { toTMDBImageUrl } from "./utils/to-tmdb-image-url.js";
 
 export const thirdPartyCast: ThirdPartyMovieResolvers["cast"] = async (

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-director.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-director.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 import { toTMDBImageUrl } from "./utils/to-tmdb-image-url.js";
 
 export const thirdPartyDirector: ThirdPartyMovieResolvers["director"] = async (

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-five-star-rating.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-five-star-rating.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 import { toFiveStarRating } from "../utils/to-five-star-rating.js";
 
 export const thirdPartyFiveStarRating: ThirdPartyMovieResolvers["fiveStarRating"] =

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-movie.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-movie.ts
@@ -1,6 +1,6 @@
 import lodash from "lodash";
 import { convertOmdbRatings } from "../../../utils/convert-omdb-ratings.js";
-import { QueryResolvers } from "../../../__generated__/graphql.js";
+import { type QueryResolvers } from "../../../__generated__/graphql.js";
 import { Genre } from "md4k-constants";
 
 const { findKey } = lodash;

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-plot.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-plot.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 
 export const thirdPartyPlot: ThirdPartyMovieResolvers["plot"] = async (
   { imdbID },

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-provider.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-provider.ts
@@ -1,6 +1,6 @@
 import lodash from "lodash";
 import { toSubscribedSources } from "../utils/to-subscribed-sources.js";
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 
 const { first } = lodash;
 

--- a/packages/api/src/graphql/resolvers/third-party-movie/third-party-trailer.ts
+++ b/packages/api/src/graphql/resolvers/third-party-movie/third-party-trailer.ts
@@ -1,5 +1,5 @@
 import lodash from "lodash";
-import { ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
+import { type ThirdPartyMovieResolvers } from "../../../__generated__/graphql.js";
 
 const { filter, find, first, isNil, pick, reject } = lodash;
 

--- a/packages/api/src/graphql/resolvers/utils/to-five-star-rating.ts
+++ b/packages/api/src/graphql/resolvers/utils/to-five-star-rating.ts
@@ -1,7 +1,7 @@
 import lodash from "lodash";
 import lodashfp from "lodash/fp.js";
 import { ratingsSources } from "md4k-constants";
-import { Maybe } from "graphql/jsutils/Maybe.js";
+import { type Maybe } from "graphql/jsutils/Maybe.js";
 
 const { isNil } = lodash;
 const { filter, flow, map, mean, pick } = lodashfp;

--- a/packages/api/src/graphql/resolvers/utils/to-subscribed-sources.ts
+++ b/packages/api/src/graphql/resolvers/utils/to-subscribed-sources.ts
@@ -1,6 +1,6 @@
 import lodash from "lodash";
 import { Source } from "md4k-constants";
-import { TMDBProviderResults } from "../../types/tmdb.types.js";
+import { type TMDBProviderResults } from "../../types/tmdb.types.js";
 
 const { isNil } = lodash;
 

--- a/packages/api/src/graphql/types/db.types.ts
+++ b/packages/api/src/graphql/types/db.types.ts
@@ -1,4 +1,4 @@
-import { ObjectId } from "mongodb";
+import { type ObjectId } from "mongodb";
 
 export type List = {
   _id: ObjectId;

--- a/packages/api/src/utils/convert-omdb-ratings.ts
+++ b/packages/api/src/utils/convert-omdb-ratings.ts
@@ -1,7 +1,7 @@
 import { fromOmdbSource } from "../constants/ratings.js";
 
 import { ratingsSources, ratingsSource } from "md4k-constants";
-import { OMDBMovie } from "../graphql/types/omdb.types.js";
+import { type OMDBMovie } from "../graphql/types/omdb.types.js";
 
 const normalizeRating = (source: string, value: string) => {
   switch (source) {

--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -1,36 +1,13 @@
 {
-  "parser": "@typescript-eslint/parser",
-  "extends": [
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:@typescript-eslint/recommended"
-  ],
-  "plugins": ["react", "@typescript-eslint"],
+  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended"],
+  "plugins": ["react"],
   "rules": {
     "react/react-in-jsx-scope": 0,
     "react/prop-types": 0,
     "react/no-unknown-property": 2,
     "jsx-a11y/alt-text": 0,
-    "react/display-name": 0,
-    "@typescript-eslint/explicit-function-return-type": 0
+    "react/display-name": 0
   },
-  "overrides": [
-    {
-      // enable the rule specifically for TypeScript files
-      "files": ["*.ts", "*.tsx"],
-      "excludedFiles": ["*.test.ts", "*.test.tsx", "**/graphql/**"],
-      "rules": {
-        "@typescript-eslint/explicit-function-return-type": 2
-      }
-    },
-    {
-      // enable the rule specifically for test files
-      "files": ["*.test.ts", "*.test.tsx"],
-      "rules": {
-        "@typescript-eslint/no-explicit-any": 0
-      }
-    }
-  ],
   "settings": {
     "react": {
       "version": "detect"

--- a/packages/web/src/components/app/app.tsx
+++ b/packages/web/src/components/app/app.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from "@auth0/auth0-react";
-import { ReactElement, useEffect } from "react";
+import { type ReactElement, useEffect } from "react";
 import { ThemeProvider, StyledEngineProvider } from "@mui/material";
 import { theme } from "../../theme/theme";
 import { AppProvider } from "../../context/app-context";

--- a/packages/web/src/components/app/components/action-button/action-button.test.tsx
+++ b/packages/web/src/components/app/components/action-button/action-button.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import ActionButton from "./action-button";
 import Close from "@mui/icons-material/Close";
-import { Mock, vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
 interface LocalTestContext {
   onClick: Mock;

--- a/packages/web/src/components/app/components/action-button/action-button.tsx
+++ b/packages/web/src/components/app/components/action-button/action-button.tsx
@@ -1,8 +1,8 @@
 import { Tooltip } from "@mui/material";
 
 import { ButtonContainer } from "./action-button.styles";
-import { SvgIconComponent } from "@mui/icons-material";
-import { ReactElement } from "react";
+import { type SvgIconComponent } from "@mui/icons-material";
+import { type ReactElement } from "react";
 
 export type ActionButtonProps = {
   Icon: SvgIconComponent;

--- a/packages/web/src/components/app/components/add/add.styles.ts
+++ b/packages/web/src/components/app/components/add/add.styles.ts
@@ -1,4 +1,4 @@
-import { Theme, styled } from "@mui/material";
+import { type Theme, styled } from "@mui/material";
 import { app } from "../../../../constants/app";
 
 export const Layout = styled("div")(({ theme: { spacing } }) => ({

--- a/packages/web/src/components/app/components/add/add.test.tsx
+++ b/packages/web/src/components/app/components/add/add.test.tsx
@@ -5,8 +5,8 @@ import { vi } from "vitest";
 import TabPanel from "./components/tab-panel/tab-panel";
 import { ADD_MOVIE, addMovieOptions } from "../../../../graphql/mutations";
 import { GraphQLError } from "graphql";
-import { TabPanelSearchProps } from "./components/tab-panel-search/tab-panel-search";
-import { TabPanelManualProps } from "./components/tab-panel-manual/tab-panel-manual";
+import { type TabPanelSearchProps } from "./components/tab-panel-search/tab-panel-search";
+import { type TabPanelManualProps } from "./components/tab-panel-manual/tab-panel-manual";
 
 const movieData = {
   id: "111-222-333",

--- a/packages/web/src/components/app/components/add/add.tsx
+++ b/packages/web/src/components/app/components/add/add.tsx
@@ -1,5 +1,5 @@
-import { Tab, Tabs, TabsOwnProps } from "@mui/material";
-import { ReactElement, useCallback, useState } from "react";
+import { Tab, Tabs, type TabsOwnProps } from "@mui/material";
+import { type ReactElement, useCallback, useState } from "react";
 import { Layout, tabStyles, tabsStyles } from "./add.styles";
 import { addMovieOptions, useAddMovie } from "../../../../graphql/mutations";
 import { useAppContext } from "../../../../context/app-context";
@@ -8,7 +8,7 @@ import TabPanelSearch from "./components/tab-panel-search/tab-panel-search";
 import TabPanelManual from "./components/tab-panel-manual/tab-panel-manual";
 import ErrorDialog from "../error-dialog/error-dialog";
 import { useTranslation } from "react-i18next";
-import { NewMovie } from "../../../../graphql/types";
+import { type NewMovie } from "../../../../graphql/types";
 
 export const Add = (): ReactElement => {
   const { t } = useTranslation(["add", "common"]);

--- a/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.test.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
-import TabPanelManual, { TabPanelManualProps } from "./tab-panel-manual";
+import TabPanelManual, { type TabPanelManualProps } from "./tab-panel-manual";
 
 interface LocalTestContext {
   props: TabPanelManualProps;

--- a/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-manual/tab-panel-manual.tsx
@@ -2,9 +2,9 @@ import TabPanel from "../tab-panel/tab-panel";
 import { ManualMovieForm } from "../../../manual-movie-form/manual-movie-form";
 import LibraryAdd from "@mui/icons-material/LibraryAdd";
 import { useNavigate } from "react-router-dom";
-import { ReactElement, useCallback } from "react";
+import { type ReactElement, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { NewMovieInput } from "../../../../../../graphql/types";
+import { type NewMovieInput } from "../../../../../../graphql/types";
 
 export type TabPanelManualProps = {
   tabId: string;

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/components/movie-quote/movie-quote.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/components/movie-quote/movie-quote.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { Attribution, Layout, Quote } from "./movie-quote.styles";
 import { useTranslation } from "react-i18next";
 import resources from "../../../../../../../../__generated__/resources";

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/components/poster-grid-item/poster-grid-item.test.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/components/poster-grid-item/poster-grid-item.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PosterGridItem, { PosterGridItemProps } from "./poster-grid-item";
+import PosterGridItem, { type PosterGridItemProps } from "./poster-grid-item";
 import { vi } from "vitest";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/components/poster-grid-item/poster-grid-item.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/components/poster-grid-item/poster-grid-item.tsx
@@ -1,8 +1,8 @@
 import { useSpring } from "react-spring";
 import MoviePoster from "../../../../../../../movie-poster/movie-poster";
 import { Layout, Title, Info } from "./poster-grid-item.styles";
-import React, { ReactElement } from "react";
-import { SearchResult } from "../../../../../../../../../../__generated__/graphql";
+import React, { type ReactElement } from "react";
+import { type SearchResult } from "../../../../../../../../../../__generated__/graphql";
 
 export type PosterGridItemProps = {
   height: number;

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/poster-grid.test.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/poster-grid.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PosterGrid, { PosterGridProps } from "./poster-grid";
+import PosterGrid, { type PosterGridProps } from "./poster-grid";
 import { vi } from "vitest";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/poster-grid.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/poster-grid.tsx
@@ -1,9 +1,9 @@
 import PosterGridItem, {
-  PosterGridItemProps,
+  type PosterGridItemProps,
 } from "./components/poster-grid-item/poster-grid-item";
 import { Layout } from "./poster-grid.styles";
-import { SearchResult } from "../../../../../../../../__generated__/graphql";
-import { ReactElement } from "react";
+import { type SearchResult } from "../../../../../../../../__generated__/graphql";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export type PosterGridProps = Pick<PosterGridItemProps, "onClick"> & {

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.test.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.test.tsx
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import TabPanelSearch, { TabPanelSearchProps } from "./tab-panel-search";
+import TabPanelSearch, { type TabPanelSearchProps } from "./tab-panel-search";
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
 import { screen } from "@testing-library/react";
 import { SEARCH_BY_TITLE } from "../../../../../../graphql/queries";

--- a/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/tab-panel-search.tsx
@@ -5,8 +5,8 @@ import Refresh from "@mui/icons-material/Refresh";
 import Search from "@mui/icons-material/Search";
 import TabPanel from "../tab-panel/tab-panel";
 import {
-  ChangeEventHandler,
-  ReactElement,
+  type ChangeEventHandler,
+  type ReactElement,
   useCallback,
   useRef,
   useState,
@@ -26,14 +26,14 @@ import MovieRemove from "mdi-material-ui/MovieRemove";
 import PosterGrid from "./components/poster-grid/poster-grid";
 import { useInViewRef } from "rooks/dist/esm/hooks/useInViewRef";
 import {
-  PageInfo,
-  SearchByTitleQuery,
-  SearchResult,
+  type PageInfo,
+  type SearchByTitleQuery,
+  type SearchResult,
 } from "../../../../../../__generated__/graphql";
-import { Maybe } from "graphql/jsutils/Maybe";
+import { type Maybe } from "graphql/jsutils/Maybe";
 import { notEmpty } from "../../../../../../utils/not-empty";
 import { useTranslation } from "react-i18next";
-import { NewMovie } from "../../../../../../graphql/types";
+import { type NewMovie } from "../../../../../../graphql/types";
 
 export type TabPanelSearchProps = {
   tabId: string;

--- a/packages/web/src/components/app/components/add/components/tab-panel/tab-panel.tsx
+++ b/packages/web/src/components/app/components/add/components/tab-panel/tab-panel.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactElement } from "react";
+import { type PropsWithChildren, type ReactElement } from "react";
 
 export type TabPanelProps = PropsWithChildren<{
   tabId: string;

--- a/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.tsx
+++ b/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import CreateListError from "./create-list-error";
-import { Mock, vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
 interface LocalTestContext {
   reset: Mock;

--- a/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.tsx
+++ b/packages/web/src/components/app/components/create/components/create-list-error/create-list-error.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@mui/material";
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import { Container } from "./create-list-error.styles";
 import { useTranslation } from "react-i18next";
 

--- a/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.tsx
+++ b/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import CreateListInput from "./create-list-input";
-import { Mock, vi } from "vitest";
+import { type Mock, vi } from "vitest";
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.tsx
+++ b/packages/web/src/components/app/components/create/components/create-list-input/create-list-input.tsx
@@ -1,5 +1,5 @@
 import { Button, FormHelperText } from "@mui/material";
-import React, { ReactElement, useState } from "react";
+import React, { type ReactElement, useState } from "react";
 import { useAppContext } from "../../../../../../context/app-context";
 import { Container, ListInput } from "./create-list-input.styles";
 import { useTranslation } from "react-i18next";

--- a/packages/web/src/components/app/components/create/create.tsx
+++ b/packages/web/src/components/app/components/create/create.tsx
@@ -4,7 +4,7 @@ import CreateListInput from "./components/create-list-input/create-list-input";
 import CreateListError from "./components/create-list-error/create-list-error";
 import { addListOptions, useAddList } from "../../../../graphql/mutations";
 import { useNavigate } from "react-router-dom";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Create = (): ReactElement => {

--- a/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.tsx
+++ b/packages/web/src/components/app/components/delete-dialog/delete-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import DeleteDialog, { DeleteDialogProps } from "./delete-dialog";
+import DeleteDialog, { type DeleteDialogProps } from "./delete-dialog";
 import { vi } from "vitest";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/delete-dialog/delete-dialog.tsx
+++ b/packages/web/src/components/app/components/delete-dialog/delete-dialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogContentText,
   DialogTitle,
 } from "@mui/material";
-import React, { ReactElement, ReactNode } from "react";
+import React, { type ReactElement, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 export type DeleteDialogProps = {

--- a/packages/web/src/components/app/components/edit/edit.styles.ts
+++ b/packages/web/src/components/app/components/edit/edit.styles.ts
@@ -1,4 +1,4 @@
-import { Theme, styled } from "@mui/material";
+import { type Theme, styled } from "@mui/material";
 import { app } from "../../../../constants/app";
 
 export const Layout = styled("div")(({ theme: { spacing } }) => ({

--- a/packages/web/src/components/app/components/edit/edit.tsx
+++ b/packages/web/src/components/app/components/edit/edit.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useMemo, useState } from "react";
+import { type ReactElement, useCallback, useMemo, useState } from "react";
 import { useAppContext } from "../../../../context/app-context";
 import { useNavigate, useParams } from "react-router-dom";
 import ErrorDialog from "../error-dialog/error-dialog";
@@ -7,9 +7,9 @@ import Check from "@mui/icons-material/Check";
 import { editMovieOptions, useEditMovie } from "../../../../graphql/mutations";
 import { Layout, NotFoundLayout, tabStyles, tabsStyles } from "./edit.styles";
 import { Tab, Tabs } from "@mui/material";
-import { Movie } from "../../../../__generated__/graphql";
+import { type Movie } from "../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
-import { NewMovieInput } from "../../../../graphql/types";
+import { type NewMovieInput } from "../../../../graphql/types";
 
 export const Edit = (): ReactElement => {
   const params = useParams();

--- a/packages/web/src/components/app/components/empty-state/empty-state.test.tsx
+++ b/packages/web/src/components/app/components/empty-state/empty-state.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import EmptyState, { EmptyStateProps } from "./empty-state";
+import EmptyState, { type EmptyStateProps } from "./empty-state";
 
 interface LocalTestContext {
   props: EmptyStateProps;

--- a/packages/web/src/components/app/components/empty-state/empty-state.tsx
+++ b/packages/web/src/components/app/components/empty-state/empty-state.tsx
@@ -1,6 +1,6 @@
 import { CircularProgress } from "@mui/material";
 import { EmptyListLayout, Img, Message, Quote } from "./empty-state.styles";
-import { ReactElement, ReactNode } from "react";
+import { type ReactElement, type ReactNode } from "react";
 
 export type EmptyStateProps = {
   imgSrc: string;

--- a/packages/web/src/components/app/components/error-dialog/error-dialog.test.tsx
+++ b/packages/web/src/components/app/components/error-dialog/error-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import ErrorDialog, { ErrorDialogProps } from "./error-dialog";
+import ErrorDialog, { type ErrorDialogProps } from "./error-dialog";
 import { vi } from "vitest";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/error-dialog/error-dialog.tsx
+++ b/packages/web/src/components/app/components/error-dialog/error-dialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogContentText,
   DialogTitle,
 } from "@mui/material";
-import { ReactElement, ReactNode } from "react";
+import { type ReactElement, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 export type ErrorDialogProps = {

--- a/packages/web/src/components/app/components/five-star-rating/five-star-rating.tsx
+++ b/packages/web/src/components/app/components/five-star-rating/five-star-rating.tsx
@@ -1,7 +1,7 @@
 import times from "lodash/times";
 import { Star, StarRatingContainer } from "./five-star-rating.styles";
-import { ReactElement } from "react";
-import { Maybe } from "../../../../__generated__/graphql";
+import { type ReactElement } from "react";
+import { type Maybe } from "../../../../__generated__/graphql";
 
 const heights = [16, 18, 20, 18, 16];
 const margins = [0, 1, 1.5, 1, 0];

--- a/packages/web/src/components/app/components/footer/footer.tsx
+++ b/packages/web/src/components/app/components/footer/footer.tsx
@@ -1,6 +1,6 @@
 import { FooterLayout } from "./footer.styles";
 import { Link } from "react-router-dom";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const Footer = (): ReactElement => {

--- a/packages/web/src/components/app/components/full-detail-modal/full-detail-modal.test.tsx
+++ b/packages/web/src/components/app/components/full-detail-modal/full-detail-modal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import FullDetailModal, { FullDetailModalProps } from "./full-detail-modal";
+import FullDetailModal, { type FullDetailModalProps } from "./full-detail-modal";
 import { vi } from "vitest";
 
 // Mock the full detail component to make this test simpler

--- a/packages/web/src/components/app/components/full-detail-modal/full-detail-modal.tsx
+++ b/packages/web/src/components/app/components/full-detail-modal/full-detail-modal.tsx
@@ -1,9 +1,9 @@
 import { useSpring } from "react-spring";
-import { ReactElement, useCallback, useEffect, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import FullDetail, { FullDetailProps } from "../full-detail/full-detail";
+import FullDetail, { type FullDetailProps } from "../full-detail/full-detail";
 import { ModalBackdrop, ModalContent } from "./full-detail-modal.styles";
-import { Maybe } from "../../../../__generated__/graphql";
+import { type Maybe } from "../../../../__generated__/graphql";
 
 export type FullDetailModalProps = {
   preload?: boolean;

--- a/packages/web/src/components/app/components/full-detail/components/actions-add/actions-add.test.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/actions-add/actions-add.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
-import { ActionsAdd, ActionsAddProps } from "./actions-add";
+import { ActionsAdd, type ActionsAddProps } from "./actions-add";
 
 interface LocalTestContext {
   props: ActionsAddProps;

--- a/packages/web/src/components/app/components/full-detail/components/actions-add/actions-add.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/actions-add/actions-add.tsx
@@ -1,6 +1,6 @@
 import LibraryAdd from "@mui/icons-material/LibraryAdd";
 import { DetailButton } from "../actions/actions.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export type ActionsAddProps = {

--- a/packages/web/src/components/app/components/full-detail/components/actions-view/actions-view.test.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/actions-view/actions-view.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
-import { ActionsView, ActionsViewProps } from "./actions-view";
+import { ActionsView, type ActionsViewProps } from "./actions-view";
 import { Source } from "md4k-constants";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/full-detail/components/actions-view/actions-view.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/actions-view/actions-view.tsx
@@ -3,7 +3,7 @@ import PlayArrow from "@mui/icons-material/PlayArrow";
 import Search from "@mui/icons-material/Search";
 import { Source } from "md4k-constants";
 import { searchStreaming, searchTorrent } from "../../../../../../utils/search";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export type ActionsViewProps = {

--- a/packages/web/src/components/app/components/full-detail/components/actions/actions.test.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/actions/actions.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
-import { Actions, ActionsProps } from "./actions";
+import { Actions, type ActionsProps } from "./actions";
 
 interface LocalTestContext {
   props: ActionsProps;

--- a/packages/web/src/components/app/components/full-detail/components/actions/actions.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/actions/actions.tsx
@@ -1,7 +1,7 @@
 import { DetailButton, Layout } from "./actions.styles";
 import TelevisionPlay from "mdi-material-ui/TelevisionPlay";
 import TelevisionOff from "mdi-material-ui/TelevisionOff";
-import { PropsWithChildren, ReactElement } from "react";
+import { type PropsWithChildren, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export type ActionsProps = PropsWithChildren<{

--- a/packages/web/src/components/app/components/full-detail/components/cast/cast.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/cast/cast.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@mui/material";
 import { Character, Headshot, Layout, Name } from "./cast.styles";
-import { ReactElement } from "react";
-import { Maybe } from "../../../../../../__generated__/graphql";
+import { type ReactElement } from "react";
+import { type Maybe } from "../../../../../../__generated__/graphql";
 
 export type CastProps = {
   name?: Maybe<string>;

--- a/packages/web/src/components/app/components/full-detail/components/footer/footer.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/footer/footer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 
 import {
   searchCommonSense,
@@ -7,7 +7,7 @@ import {
   searchTMDB,
 } from "../../../../../../utils/search";
 import { ActionImage, Container } from "./footer.styles";
-import { Maybe } from "../../../../../../__generated__/graphql";
+import { type Maybe } from "../../../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
 
 export type FooterProps = {

--- a/packages/web/src/components/app/components/full-detail/components/full-detail-skeleton/full-detail.skeleton.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/full-detail-skeleton/full-detail.skeleton.tsx
@@ -11,7 +11,7 @@ import {
   PlotLayout,
   Poster,
 } from "../../full-detail.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 
 export type FullDetailSkeletonProps = {
   showCloseButton?: boolean;

--- a/packages/web/src/components/app/components/full-detail/components/rated/rated.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/rated/rated.tsx
@@ -1,7 +1,7 @@
 import isNil from "lodash/isNil";
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import { RatedContainer } from "./rated.styles";
-import { Maybe } from "../../../../../../__generated__/graphql";
+import { type Maybe } from "../../../../../../__generated__/graphql";
 
 export type RatedProps = {
   rated?: Maybe<string>;

--- a/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/scroll-area/scroll-area.tsx
@@ -1,9 +1,9 @@
 import { useSpring } from "react-spring";
-import { ReactElement, UIEvent, useCallback, useState } from "react";
+import { type ReactElement, type UIEvent, useCallback, useState } from "react";
 import { useOnWindowResize } from "rooks";
 
 import { Layout, Shade, TextArea } from "./scroll-area.styles";
-import { Maybe } from "../../../../../../__generated__/graphql";
+import { type Maybe } from "../../../../../../__generated__/graphql";
 
 export type ScrollAreaProps = {
   text?: Maybe<string>;

--- a/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.test.tsx
@@ -1,7 +1,7 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { createMatchMedia } from "../../../../../../test-utils/create-match-media";
 import { StarRatingLayout } from "./star-rating-layout";
-import { Ratings } from "../../../../../../__generated__/graphql";
+import { type Ratings } from "../../../../../../__generated__/graphql";
 
 interface LocalTestContext {
   ratings: Ratings;

--- a/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/star-rating-layout/star-rating-layout.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { type ReactElement, useState } from "react";
 import { animated, useSpring } from "react-spring";
 import debounce from "lodash/debounce";
 import { useMediaQuery } from "@mui/material";
@@ -7,8 +7,8 @@ import { RatingContainer } from "./star-rating-layout.styles";
 import FiveStarRating from "../../../five-star-rating/five-star-rating";
 import Ratings from "../../../list/components/ratings/ratings";
 import {
-  Maybe,
-  Ratings as RatingsGQLType,
+  type Maybe,
+  type Ratings as RatingsGQLType,
 } from "../../../../../../__generated__/graphql";
 
 export type StarRatingLayoutProps = {

--- a/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/trailer/trailer.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import Trailer from "./trailer";
-import { Mock, vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
 vi.mock("react-youtube", () => ({
   default: () => <div data-testid="youtube" />,

--- a/packages/web/src/components/app/components/full-detail/components/trailer/trailer.tsx
+++ b/packages/web/src/components/app/components/full-detail/components/trailer/trailer.tsx
@@ -1,7 +1,7 @@
 import { useOnWindowResize } from "rooks";
 
 import { useSpring } from "react-spring";
-import { ReactElement, useCallback, useState } from "react";
+import { type ReactElement, useCallback, useState } from "react";
 import {
   TrailerInline,
   TrailerOverlay,

--- a/packages/web/src/components/app/components/full-detail/full-detail.test.tsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.test.tsx
@@ -1,4 +1,4 @@
-import FullDetail, { FullDetailProps } from "./full-detail";
+import FullDetail, { type FullDetailProps } from "./full-detail";
 import { waitFor, screen } from "@testing-library/react";
 import { Source } from "md4k-constants";
 import { vi, beforeEach } from "vitest";

--- a/packages/web/src/components/app/components/full-detail/full-detail.tsx
+++ b/packages/web/src/components/app/components/full-detail/full-detail.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useMemo, useState } from "react";
+import { type ReactElement, useCallback, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useMediaQuery } from "@mui/material";
 import ChevronLeft from "@mui/icons-material/ChevronLeft";
@@ -43,11 +43,11 @@ import { ActionsAdd } from "./components/actions-add/actions-add";
 import { ActionsView } from "./components/actions-view/actions-view";
 import Cast from "./components/cast/cast";
 import { Actions } from "./components/actions/actions";
-import { Movie } from "../../../../__generated__/graphql";
+import { type Movie } from "../../../../__generated__/graphql";
 import { notEmpty } from "../../../../utils/not-empty";
 import { useTranslation } from "react-i18next";
-import resources from "../../../../__generated__/resources";
-import { NewMovie } from "../../../../graphql/types";
+import type resources from "../../../../__generated__/resources";
+import { type NewMovie } from "../../../../graphql/types";
 
 export type FullDetailProps = {
   movie: Omit<Movie, "id" | "list">; // This needs to omit id and list because it could be a SearchResult which creates additional type issues. This makes Movie basically an interface/Partial but with a required title.

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.tsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
-import ActionBar, { ActionBarProps } from "./action-bar";
+import ActionBar, { type ActionBarProps } from "./action-bar";
 
 const { MOCK_USE_MEDIA_QUERY } = vi.hoisted(() => ({
   MOCK_USE_MEDIA_QUERY: vi.fn().mockReturnValue(true),

--- a/packages/web/src/components/app/components/list/components/action-bar/action-bar.tsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/action-bar.tsx
@@ -9,8 +9,8 @@ import {
   SecondaryActions,
 } from "./action-bar.styles";
 import { useNavigate } from "react-router-dom";
-import { ReactElement } from "react";
-import { PickOption } from "../../../../../../types";
+import { type ReactElement } from "react";
+import { type PickOption } from "../../../../../../types";
 import { useTranslation } from "react-i18next";
 
 export type ActionBarProps = {

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.styles.ts
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.styles.ts
@@ -1,4 +1,4 @@
-import { Theme, styled } from "@mui/material";
+import { type Theme, styled } from "@mui/material";
 
 export const SortNavList = styled("ul")(
   ({ theme: { breakpoints, spacing } }) => ({

--- a/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.tsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/sort-nav/sort-nav.tsx
@@ -9,9 +9,9 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useOrderAndDirection } from "../../../../../../../../hooks/use-order-and-direction";
 import { sort, SortDirection } from "../../../../../../../../constants/sorts";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import resources from "../../../../../../../../__generated__/resources";
+import type resources from "../../../../../../../../__generated__/resources";
 
 const SortNav = (): ReactElement => {
   const { t } = useTranslation(["list"]);

--- a/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.tsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.test.tsx
@@ -1,5 +1,5 @@
 import { waitFor, screen } from "@testing-library/react";
-import { Mock, vi } from "vitest";
+import { type Mock, vi } from "vitest";
 import SplitButton from "./split-button";
 import { renderWithProviders } from "../../../../../../../../test-utils/render-with-providers";
 

--- a/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.tsx
+++ b/packages/web/src/components/app/components/list/components/action-bar/components/split-button/split-button.tsx
@@ -1,5 +1,5 @@
 import { Button, ClickAwayListener, MenuItem, MenuList } from "@mui/material";
-import { ReactElement, useState } from "react";
+import { type ReactElement, useState } from "react";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ClockIcon from "mdi-material-ui/ClockOutline";
 import ClockFastIcon from "mdi-material-ui/ClockFast";
@@ -18,10 +18,10 @@ import {
 } from "./split-button.styles";
 import { filterMovies } from "../../../../../../../../utils/filter-movies";
 import { useAppContext } from "../../../../../../../../context/app-context";
-import { PickOption } from "../../../../../../../../types";
-import { SvgIconComponent } from "@mui/icons-material";
+import { type PickOption } from "../../../../../../../../types";
+import { type SvgIconComponent } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
-import resources from "../../../../../../../../__generated__/resources";
+import type resources from "../../../../../../../../__generated__/resources";
 
 const splitButtonItems: {
   value: string;

--- a/packages/web/src/components/app/components/list/components/countdown/countdown.tsx
+++ b/packages/web/src/components/app/components/list/components/countdown/countdown.tsx
@@ -9,7 +9,7 @@ import {
   Number,
   VerticalLine,
 } from "./countdown.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useSpring } from "react-spring";
 
 export const Countdown = (): ReactElement => {

--- a/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/empty-list/empty-list.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@mui/material";
 import EmptyState from "../../../../../empty-state/empty-state";
 import { useNavigate } from "react-router-dom";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const EmptyList = (): ReactElement => {

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import MovieSection, { MovieSectionProps } from "./movie-section";
+import MovieSection, { type MovieSectionProps } from "./movie-section";
 import { vi } from "vitest";
-import { MovieProps } from "../movie/movie";
+import { type MovieProps } from "../movie/movie";
 
 vi.mock("../movie/movie", () => ({
   default: ({

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie-section/movie-section.tsx
@@ -5,16 +5,16 @@ import {
 } from "./movie-section.styles";
 import Movie from "../movie/movie";
 import {
-  ReactElement,
-  ReactNode,
+  type ReactElement,
+  type ReactNode,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react";
 import { useOnWindowResize } from "rooks";
-import { Movie as MovieType } from "../../../../../../../../__generated__/graphql";
-import { ListGridHandlers } from "../../types";
+import { type Movie as MovieType } from "../../../../../../../../__generated__/graphql";
+import { type ListGridHandlers } from "../../types";
 
 export type MovieSectionProps = ListGridHandlers & {
   ariaLabel?: string;

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import DetailActions, { DetailActionsProps } from "./detail-actions";
+import DetailActions, { type DetailActionsProps } from "./detail-actions";
 import { vi } from "vitest";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/detail-actions/detail-actions.tsx
@@ -6,8 +6,8 @@ import UnlockIcon from "mdi-material-ui/LockOpenVariant";
 
 import { Actions } from "./detail-actions.styles";
 import ActionButton from "../../../../../../../action-button/action-button";
-import { Movie } from "../../../../../../../../../../__generated__/graphql";
-import { ReactElement } from "react";
+import { type Movie } from "../../../../../../../../../../__generated__/graphql";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export type DetailActionsProps = {

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/source/source.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/components/source/source.tsx
@@ -1,9 +1,9 @@
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { sourceLogos } from "../../../../../../../../../../constants/sources";
 import { SourceBorder, SourceImage, SourceLayout } from "./source.styles";
 import { Source as SourceConstants } from "md4k-constants";
 import { useTranslation } from "react-i18next";
-import { Maybe } from "../../../../../../../../../../__generated__/graphql";
+import { type Maybe } from "../../../../../../../../../../__generated__/graphql";
 
 export type SourceProps = {
   source?: Maybe<SourceConstants>;

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/hooks/useChangeBackdrop.test.ts
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/hooks/useChangeBackdrop.test.ts
@@ -2,7 +2,7 @@ import { vi } from "vitest";
 import { useChangeBackdrop } from "./useChangeBackdrop";
 import { renderHookWithProviders } from "../../../../../../../../../test-utils/render-with-providers";
 import { EDIT_MOVIE } from "../../../../../../../../../graphql/mutations";
-import { RenderHookResult, waitFor } from "@testing-library/react";
+import { type RenderHookResult, waitFor } from "@testing-library/react";
 
 const MOVIE_MOCK = {
   id: "8502fd8b-165e-4239-965f-b46f8d523829",

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/hooks/useChangeBackdrop.ts
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/hooks/useChangeBackdrop.ts
@@ -4,7 +4,7 @@ import {
   editMovieOptions,
   useEditMovie,
 } from "../../../../../../../../../graphql/mutations";
-import { Movie } from "../../../../../../../../../__generated__/graphql";
+import { type Movie } from "../../../../../../../../../__generated__/graphql";
 
 export const useChangeBackdrop = (
   movie: Movie

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.styles.ts
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.styles.ts
@@ -1,4 +1,4 @@
-import { Theme, styled } from "@mui/material";
+import { type Theme, styled } from "@mui/material";
 import { animated } from "react-spring";
 
 export const MovieContainer = styled(animated.div)(() => ({

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.tsx
@@ -1,10 +1,10 @@
 import { waitFor, screen } from "@testing-library/react";
-import Movie, { MovieProps } from "./movie";
+import Movie, { type MovieProps } from "./movie";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../../../test-utils/render-with-providers";
 import { Globals } from "react-spring";
 import { UPDATE_MOVIE } from "../../../../../../../../graphql/mutations/update-movie";
-import { FullDetailModalProps } from "../../../../../full-detail-modal/full-detail-modal";
+import { type FullDetailModalProps } from "../../../../../full-detail-modal/full-detail-modal";
 
 Globals.assign({
   skipAnimation: true,

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef, useState } from "react";
+import React, { type ReactElement, useRef, useState } from "react";
 import { useSpring } from "react-spring";
 import debounce from "lodash/debounce";
 
@@ -26,8 +26,8 @@ import FullDetailModal from "../../../../../full-detail-modal/full-detail-modal"
 import { useResponsive } from "../../../../../../../../hooks/use-responsive";
 import { useUpdateMovie } from "../../../../../../../../graphql/mutations/update-movie";
 import { useChangeBackdrop } from "./hooks/useChangeBackdrop";
-import { Movie as MovieType } from "../../../../../../../../__generated__/graphql";
-import { ListGridHandlers } from "../../types";
+import { type Movie as MovieType } from "../../../../../../../../__generated__/graphql";
+import { type ListGridHandlers } from "../../types";
 
 const isTouchInterface = "ontouchstart" in window;
 

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.test.tsx
@@ -2,8 +2,8 @@ import { render, within, screen } from "@testing-library/react";
 import SortedAdded from "./sorted-added";
 import { vi } from "vitest";
 import { formatISO, subDays, subMonths } from "date-fns";
-import { MovieProps } from "../movie/movie";
-import { ListGridProps } from "../../types";
+import { type MovieProps } from "../movie/movie";
+import { type ListGridProps } from "../../types";
 
 const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
   MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-added/sorted-added.tsx
@@ -1,13 +1,13 @@
 import { differenceInDays, parseISO } from "date-fns";
 import orderBy from "lodash/orderBy";
 import { flow, groupBy, mapValues } from "lodash/fp";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { sort, SortDirection } from "../../../../../../../../constants/sorts";
 import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
 import MovieSection from "../movie-section/movie-section";
-import { ListGridProps } from "../../types";
-import { Movie } from "../../../../../../../../__generated__/graphql";
-import { Dictionary, List } from "lodash";
+import { type ListGridProps } from "../../types";
+import { type Movie } from "../../../../../../../../__generated__/graphql";
+import { type Dictionary, type List } from "lodash";
 import { useTranslation } from "react-i18next";
 
 const partitionMovies = (

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.test.tsx
@@ -1,8 +1,8 @@
 import { render, within, screen } from "@testing-library/react";
 import SortedGenre from "./sorted-genre";
 import { vi } from "vitest";
-import { MovieProps } from "../movie/movie";
-import { ListGridProps } from "../../types";
+import { type MovieProps } from "../movie/movie";
+import { type ListGridProps } from "../../types";
 
 const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
   MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-genre/sorted-genre.tsx
@@ -1,13 +1,13 @@
 import orderBy from "lodash/orderBy";
 import { flow, groupBy, mapValues } from "lodash/fp";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
 import MovieSection from "../movie-section/movie-section";
 import { sort, SortDirection } from "../../../../../../../../constants/sorts";
-import { ListGridProps } from "../../types";
-import { Movie } from "../../../../../../../../__generated__/graphql";
+import { type ListGridProps } from "../../types";
+import { type Movie } from "../../../../../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
-import resources from "../../../../../../../../__generated__/resources";
+import type resources from "../../../../../../../../__generated__/resources";
 
 const SortedGenre = ({ movies, ...handlers }: ListGridProps): ReactElement => {
   const { t } = useTranslation(["common"]);

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.test.tsx
@@ -1,8 +1,8 @@
 import { render, within, screen } from "@testing-library/react";
 import SortedRating from "./sorted-rating";
 import { vi } from "vitest";
-import { MovieProps } from "../movie/movie";
-import { ListGridProps } from "../../types";
+import { type MovieProps } from "../movie/movie";
+import { type ListGridProps } from "../../types";
 
 const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
   MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-rating/sorted-rating.tsx
@@ -1,12 +1,12 @@
 import orderBy from "lodash/orderBy";
 import { flow, groupBy, mapValues } from "lodash/fp";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
 import MovieSection from "../movie-section/movie-section";
 import { sort, SortDirection } from "../../../../../../../../constants/sorts";
 import FiveStarRating from "../../../../../five-star-rating/five-star-rating";
-import { Movie } from "../../../../../../../../__generated__/graphql";
-import { ListGridProps } from "../../types";
+import { type Movie } from "../../../../../../../../__generated__/graphql";
+import { type ListGridProps } from "../../types";
 import { useTranslation } from "react-i18next";
 
 const partitionMovies = flow(

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.test.tsx
@@ -1,8 +1,8 @@
 import { render, within, screen } from "@testing-library/react";
 import SortedRuntime from "./sorted-runtime";
 import { vi } from "vitest";
-import { MovieProps } from "../movie/movie";
-import { ListGridProps } from "../../types";
+import { type MovieProps } from "../movie/movie";
+import { type ListGridProps } from "../../types";
 
 const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
   MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-runtime/sorted-runtime.tsx
@@ -1,11 +1,11 @@
 import orderBy from "lodash/orderBy";
 import { flow, groupBy, mapValues } from "lodash/fp";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { sort, SortDirection } from "../../../../../../../../constants/sorts";
 import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
 import MovieSection from "../movie-section/movie-section";
-import { Movie } from "../../../../../../../../__generated__/graphql";
-import { ListGridProps } from "../../types";
+import { type Movie } from "../../../../../../../../__generated__/graphql";
+import { type ListGridProps } from "../../types";
 import { useTranslation } from "react-i18next";
 
 const partitionMovies = flow(

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.test.tsx
@@ -2,8 +2,8 @@ import { render, within, screen } from "@testing-library/react";
 import SortedSource from "./sorted-source";
 import { vi } from "vitest";
 import { Source } from "md4k-constants";
-import { MovieProps } from "../movie/movie";
-import { ListGridProps } from "../../types";
+import { type MovieProps } from "../movie/movie";
+import { type ListGridProps } from "../../types";
 
 const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
   MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-source/sorted-source.tsx
@@ -4,17 +4,17 @@ import groupBy from "lodash/fp/groupBy";
 import mapValues from "lodash/fp/mapValues";
 import toPairs from "lodash/fp/toPairs";
 import reduce from "lodash/fp/reduce";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
 import MovieSection from "../movie-section/movie-section";
 import { sort, SortDirection } from "../../../../../../../../constants/sorts";
 import { sourceLogosLarge } from "../../../../../../../../constants/sources";
 import { Source } from "md4k-constants";
-import { ListGridProps } from "../../types";
-import { Movie } from "../../../../../../../../__generated__/graphql";
+import { type ListGridProps } from "../../types";
+import { type Movie } from "../../../../../../../../__generated__/graphql";
 import { notEmpty } from "../../../../../../../../utils/not-empty";
 import { useTranslation } from "react-i18next";
-import resources from "../../../../../../../../__generated__/resources";
+import type resources from "../../../../../../../../__generated__/resources";
 
 const preferredSourceOrder: number[] = [
   Source.PLEX,

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.test.tsx
@@ -1,8 +1,8 @@
 import { render, within, screen } from "@testing-library/react";
 import SortedTitle from "./sorted-title";
 import { vi } from "vitest";
-import { MovieProps } from "../movie/movie";
-import { ListGridProps } from "../../types";
+import { type MovieProps } from "../movie/movie";
+import { type ListGridProps } from "../../types";
 
 const { MOCK_USE_SORT_DIRECTION } = vi.hoisted(() => ({
   MOCK_USE_SORT_DIRECTION: vi.fn().mockReturnValue("asc"),

--- a/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/sorted-title/sorted-title.tsx
@@ -1,9 +1,9 @@
 import orderBy from "lodash/orderBy";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { sort } from "../../../../../../../../constants/sorts";
 import { useSortDirection } from "../../../../../../../../hooks/use-sort-direction";
 import MovieSection from "../movie-section/movie-section";
-import { ListGridProps } from "../../types";
+import { type ListGridProps } from "../../types";
 
 const SortedTitle = ({ movies, ...handlers }: ListGridProps): ReactElement => {
   const direction = useSortDirection();

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.test.tsx
@@ -2,8 +2,8 @@ import { screen } from "@testing-library/react";
 import ListGrid from "./list-grid";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
-import { MovieProps } from "./components/movie/movie";
-import { ListGridProps } from "./types";
+import { type MovieProps } from "./components/movie/movie";
+import { type ListGridProps } from "./types";
 
 vi.mock("./components/movie/movie", () => ({
   default: ({ onRemoveMovie, movie }: MovieProps) => (

--- a/packages/web/src/components/app/components/list/components/list-grid/list-grid.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/list-grid.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { type ReactElement, useState } from "react";
 import isNil from "lodash/isNil";
 
 import DeleteDialog from "../../../delete-dialog/delete-dialog";
@@ -11,8 +11,8 @@ import SortedGenre from "./components/sorted-genre/sorted-genre";
 import { sort } from "../../../../../../constants/sorts";
 import SortedRating from "./components/sorted-rating/sorted-rating";
 import SortedSource from "./components/sorted-source/sorted-source";
-import { Movie } from "../../../../../../__generated__/graphql";
-import { ListGridProps } from "./types";
+import { type Movie } from "../../../../../../__generated__/graphql";
+import { type ListGridProps } from "./types";
 
 const ListGrid = ({
   movies,

--- a/packages/web/src/components/app/components/list/components/list-grid/types/index.ts
+++ b/packages/web/src/components/app/components/list/components/list-grid/types/index.ts
@@ -1,4 +1,4 @@
-import { Movie } from "../../../../../../../__generated__/graphql";
+import { type Movie } from "../../../../../../../__generated__/graphql";
 
 export type ListGridProps = ListGridHandlers & {
   movies?: Movie[];

--- a/packages/web/src/components/app/components/list/components/ratings/ratings.tsx
+++ b/packages/web/src/components/app/components/list/components/ratings/ratings.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 
 import { ratingsSource } from "md4k-constants";
 import { ratingsSourceImage } from "../../../../../../constants/ratings";
@@ -11,8 +11,8 @@ import {
   RatingsSourceIcon,
 } from "./ratings.styles";
 import {
-  Maybe,
-  Ratings as RatingsType,
+  type Maybe,
+  type Ratings as RatingsType,
 } from "../../../../../../__generated__/graphql";
 
 export type RatingsProps = {

--- a/packages/web/src/components/app/components/list/list.test.tsx
+++ b/packages/web/src/components/app/components/list/list.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { renderWithProvidersAsRoute } from "../../../../test-utils/render-with-providers";
 import { List } from "./list";
-import { SpyInstance, vi } from "vitest";
+import { type SpyInstance, vi } from "vitest";
 import * as appContext from "../../../../context/app-context";
 
 import { Globals } from "react-spring";
@@ -12,17 +12,17 @@ import {
   REMOVE_MOVIE,
 } from "../../../../graphql/mutations";
 import { GET_LISTS } from "../../../../graphql/queries";
-import { ListGridProps } from "./components/list-grid/types";
+import { type ListGridProps } from "./components/list-grid/types";
 import {
-  EditMovieMutation,
-  EditMovieMutationVariables,
-  MarkWatchedMutation,
-  MarkWatchedMutationVariables,
-  Movie,
-  RemoveMovieMutation,
-  RemoveMovieMutationVariables,
+  type EditMovieMutation,
+  type EditMovieMutationVariables,
+  type MarkWatchedMutation,
+  type MarkWatchedMutationVariables,
+  type Movie,
+  type RemoveMovieMutation,
+  type RemoveMovieMutationVariables,
 } from "../../../../__generated__/graphql";
-import { MockedResponse } from "@apollo/client/testing";
+import { type MockedResponse } from "@apollo/client/testing";
 
 Globals.assign({
   skipAnimation: true,

--- a/packages/web/src/components/app/components/list/list.tsx
+++ b/packages/web/src/components/app/components/list/list.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useState } from "react";
+import { type ReactElement, useCallback, useState } from "react";
 import { useAppContext } from "../../../../context/app-context";
 import {
   editMovieOptions,
@@ -17,8 +17,8 @@ import ActionBar from "./components/action-bar/action-bar";
 import ListGrid from "./components/list-grid/list-grid";
 import ErrorDialog from "../error-dialog/error-dialog";
 import map from "lodash/map";
-import { Movie } from "../../../../__generated__/graphql";
-import { PickOption } from "../../../../types";
+import { type Movie } from "../../../../__generated__/graphql";
+import { type PickOption } from "../../../../types";
 import { useTranslation } from "react-i18next";
 
 export const List = (): ReactElement => {

--- a/packages/web/src/components/app/components/manual-movie-form/components/genre-select/genre-select.test.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/genre-select/genre-select.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import GenreSelect, { GenreSelectProps } from "./genre-select";
+import GenreSelect, { type GenreSelectProps } from "./genre-select";
 import { Genre, genres } from "md4k-constants";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/web/src/components/app/components/manual-movie-form/components/genre-select/genre-select.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/genre-select/genre-select.tsx
@@ -1,13 +1,13 @@
 import {
   MenuItem,
   Select,
-  SelectChangeEvent,
-  SelectProps,
+  type SelectChangeEvent,
+  type SelectProps,
 } from "@mui/material";
 
 import ListSelectItem from "../list-select-item/list-select-item";
-import { ReactElement } from "react";
-import { Genre, genres } from "md4k-constants";
+import { type ReactElement } from "react";
+import { type Genre, genres } from "md4k-constants";
 import { useTranslation } from "react-i18next";
 
 export type GenreSelectProps = {

--- a/packages/web/src/components/app/components/manual-movie-form/components/list-select-item/list-select-item.test.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/list-select-item/list-select-item.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import ListSelectItem, { ListSelectItemProps } from "./list-select-item";
+import ListSelectItem, { type ListSelectItemProps } from "./list-select-item";
 import { Source } from "md4k-constants";
 import { it, expect, beforeEach } from "vitest";
 

--- a/packages/web/src/components/app/components/manual-movie-form/components/list-select-item/list-select-item.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/list-select-item/list-select-item.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { Item } from "./list-select-item.styles";
 
 export type ListSelectItemProps = {

--- a/packages/web/src/components/app/components/manual-movie-form/components/source-select/source-select.test.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/source-select/source-select.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import SourceSelect, { SourceSelectProps } from "./source-select";
+import SourceSelect, { type SourceSelectProps } from "./source-select";
 import { Source, sources } from "md4k-constants";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sourceLogos } from "../../../../../../constants/sources";

--- a/packages/web/src/components/app/components/manual-movie-form/components/source-select/source-select.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/source-select/source-select.tsx
@@ -1,13 +1,13 @@
 import {
   MenuItem,
   Select,
-  SelectChangeEvent,
-  SelectProps,
+  type SelectChangeEvent,
+  type SelectProps,
 } from "@mui/material";
 
 import ListSelectItem from "../list-select-item/list-select-item";
-import { ReactElement } from "react";
-import { Source, sources } from "md4k-constants";
+import { type ReactElement } from "react";
+import { type Source, sources } from "md4k-constants";
 import { sourceLogos } from "../../../../../../constants/sources";
 import { useTranslation } from "react-i18next";
 

--- a/packages/web/src/components/app/components/manual-movie-form/components/text-input/text-input.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/components/text-input/text-input.tsx
@@ -1,8 +1,8 @@
 import { TextField } from "@mui/material";
 import { Label } from "../../manual-movie-form.styles";
-import { Controller, UseControllerProps } from "react-hook-form";
-import { ReactElement } from "react";
-import { MovieFormFields } from "../../types";
+import { Controller, type UseControllerProps } from "react-hook-form";
+import { type ReactElement } from "react";
+import { type MovieFormFields } from "../../types";
 
 export type TextInputProps = {
   controllerProps: UseControllerProps<MovieFormFields>;

--- a/packages/web/src/components/app/components/manual-movie-form/manual-movie-form.test.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/manual-movie-form.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import { vi } from "vitest";
 import { Source } from "md4k-constants";
 import { Genre } from "md4k-constants";
-import { ManualMovieForm, ManualMovieFormProps } from "./manual-movie-form";
+import { ManualMovieForm, type ManualMovieFormProps } from "./manual-movie-form";
 import Clear from "@mui/icons-material/Clear";
 
 interface LocalTestContext {

--- a/packages/web/src/components/app/components/manual-movie-form/manual-movie-form.tsx
+++ b/packages/web/src/components/app/components/manual-movie-form/manual-movie-form.tsx
@@ -9,17 +9,17 @@ import {
   SmallField,
 } from "./manual-movie-form.styles";
 import { Button } from "@mui/material";
-import { ReactElement, useMemo } from "react";
+import { type ReactElement, useMemo } from "react";
 import { formatRuntime } from "../../../../utils/format-runtime";
 import Clear from "@mui/icons-material/Clear";
 import isNil from "lodash/isNil";
 import { parseRuntime } from "../../../../utils/parse-runtime";
 import TextInput from "./components/text-input/text-input.jsx";
-import { Movie } from "../../../../__generated__/graphql";
-import { SvgIconComponent } from "@mui/icons-material";
-import { MovieFormFields } from "./types";
+import { type Movie } from "../../../../__generated__/graphql";
+import { type SvgIconComponent } from "@mui/icons-material";
+import { type MovieFormFields } from "./types";
 import { useTranslation } from "react-i18next";
-import { NewMovieInput } from "../../../../graphql/types";
+import { type NewMovieInput } from "../../../../graphql/types";
 import GenreSelect from "./components/genre-select/genre-select";
 import SourceSelect from "./components/source-select/source-select";
 

--- a/packages/web/src/components/app/components/manual-movie-form/types/index.ts
+++ b/packages/web/src/components/app/components/manual-movie-form/types/index.ts
@@ -1,4 +1,4 @@
-import { Movie } from "../../../../../__generated__/graphql";
+import { type Movie } from "../../../../../__generated__/graphql";
 
 // TODO: This could probably be more accurate and specify only what the form provides.
 export type MovieFormFields = Omit<Movie, "runtime"> & {

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.test.tsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import MoviePoster, { MoviePosterProps } from "./movie-poster";
+import MoviePoster, { type MoviePosterProps } from "./movie-poster";
 import { vi } from "vitest";
 
 const { MOCK_USE_IN_VIEW_REF } = vi.hoisted(() => ({

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.tsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.tsx
@@ -9,8 +9,8 @@ import {
   shadowStyles,
 } from "./movie-poster.styles";
 import { useInViewRef } from "rooks/dist/esm/hooks/useInViewRef";
-import { ReactElement } from "react";
-import { Maybe } from "../../../../__generated__/graphql";
+import { type ReactElement } from "react";
+import { type Maybe } from "../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
 
 export type MoviePosterProps = {

--- a/packages/web/src/components/app/components/pick/pick.tsx
+++ b/packages/web/src/components/app/components/pick/pick.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 
 import { useAppContext } from "../../../../context/app-context";
 import { errorCodes } from "md4k-constants";
@@ -10,7 +10,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import EmptyState from "../empty-state/empty-state";
 import { Button } from "@mui/material";
 import { filterMovies } from "../../../../utils/filter-movies";
-import { Movie } from "../../../../__generated__/graphql";
+import { type Movie } from "../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
 
 const getSearchParam = (

--- a/packages/web/src/components/app/components/titlebar/components/db-select/db-select.tsx
+++ b/packages/web/src/components/app/components/titlebar/components/db-select/db-select.tsx
@@ -1,9 +1,9 @@
-import { MenuItem, Button, Divider, SelectChangeEvent } from "@mui/material";
+import { MenuItem, Button, Divider, type SelectChangeEvent } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
 import { useAppContext } from "../../../../../../context/app-context";
 import { Select } from "./db-select.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const NEW_LIST = "NEW_LIST";

--- a/packages/web/src/components/app/components/titlebar/components/logo/logo.tsx
+++ b/packages/web/src/components/app/components/titlebar/components/logo/logo.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 
 import { LogoContainer } from "./logo.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const Logo = (): ReactElement => {

--- a/packages/web/src/components/app/components/titlebar/components/nav-button/nav-button.tsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-button/nav-button.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@mui/material";
-import { PropsWithChildren, ReactElement, ReactNode } from "react";
+import { type PropsWithChildren, type ReactElement, type ReactNode } from "react";
 
 export type NavButtonProps = {
   href?: string;

--- a/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.tsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-full/nav-full.tsx
@@ -6,7 +6,7 @@ import { Nav } from "./nav-full.styles";
 import { useAppContext } from "../../../../../../context/app-context";
 import DbSelect from "../db-select/db-select";
 import NavButton from "../nav-button/nav-button";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const NavFull = (): ReactElement => {

--- a/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.styles.ts
+++ b/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.styles.ts
@@ -1,4 +1,4 @@
-import { styled, Divider, Theme } from "@mui/material";
+import { styled, Divider, type Theme } from "@mui/material";
 import Refresh from "@mui/icons-material/Refresh";
 import Eye from "mdi-material-ui/Eye";
 import Movie from "mdi-material-ui/Movie";

--- a/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.tsx
+++ b/packages/web/src/components/app/components/titlebar/components/nav-hamburger/nav-hamburger.tsx
@@ -1,8 +1,8 @@
-import { MouseEventHandler, ReactElement, useState } from "react";
+import { type MouseEventHandler, type ReactElement, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
   ClickAwayListener,
-  ClickAwayListenerProps,
+  type ClickAwayListenerProps,
   IconButton,
   Menu,
   MenuItem,

--- a/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.tsx
+++ b/packages/web/src/components/app/components/titlebar/components/profile-menu/profile-menu.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useRef, useState } from "react";
+import { type ReactElement, useRef, useState } from "react";
 import { ClickAwayListener, Popover, Button } from "@mui/material";
 import { useAuth0 } from "@auth0/auth0-react";
 

--- a/packages/web/src/components/app/components/titlebar/titlebar.styles.ts
+++ b/packages/web/src/components/app/components/titlebar/titlebar.styles.ts
@@ -1,7 +1,7 @@
 import { styled } from "@mui/system";
 import { app } from "../../../../constants/app";
 import NavButton from "./components/nav-button/nav-button";
-import { Theme } from "@mui/material";
+import { type Theme } from "@mui/material";
 
 export const appBarContainerStyles = ({ palette, zIndex }: Theme) =>
   ({

--- a/packages/web/src/components/app/components/titlebar/titlebar.tsx
+++ b/packages/web/src/components/app/components/titlebar/titlebar.tsx
@@ -13,7 +13,7 @@ import {
   pickScreenToolbarStyles,
   toolbarStyles,
 } from "./titlebar.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const TitleBar = (): ReactElement => {

--- a/packages/web/src/components/app/components/toast/toast.tsx
+++ b/packages/web/src/components/app/components/toast/toast.tsx
@@ -1,7 +1,7 @@
 import { Button, IconButton, Snackbar } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { useAppContext } from "../../../../context/app-context";
-import { ReactElement, useCallback } from "react";
+import { type ReactElement, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 const Toast = (): ReactElement => {

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.styles.ts
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.styles.ts
@@ -1,4 +1,4 @@
-import { Theme, styled } from "@mui/material";
+import { type Theme, styled } from "@mui/material";
 import { animated } from "react-spring";
 
 export const Picker = styled(animated.div)(({ theme: { palette } }) => ({

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.tsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.test.tsx
@@ -1,8 +1,8 @@
 import { screen } from "@testing-library/react";
-import DatePicker, { DatePickerProps } from "./date-picker";
+import DatePicker, { type DatePickerProps } from "./date-picker";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
-import { SpringValues } from "react-spring";
+import { type SpringValues } from "react-spring";
 
 interface LocalTestContext {
   props: DatePickerProps;

--- a/packages/web/src/components/app/components/watched/components/date-picker/date-picker.tsx
+++ b/packages/web/src/components/app/components/watched/components/date-picker/date-picker.tsx
@@ -1,6 +1,6 @@
 import "react-day-picker/dist/style.css";
 
-import { MouseEventHandler, ReactElement, useState } from "react";
+import { type MouseEventHandler, type ReactElement, useState } from "react";
 import { Drawer } from "@mui/material";
 import Close from "@mui/icons-material/Close";
 import Delete from "@mui/icons-material/Delete";
@@ -18,7 +18,7 @@ import {
   dayPickerSmallStyles,
 } from "./date-picker.styles";
 import ActionButton from "../../../action-button/action-button";
-import { SpringValues } from "react-spring";
+import { type SpringValues } from "react-spring";
 
 const preventBubbling: MouseEventHandler = (e) => e.stopPropagation();
 

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.tsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.tsx
@@ -1,6 +1,6 @@
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
 import { buildMovieMock } from "../../../../../../test-utils/build-movie-mock";
-import WatchedMovie, { WatchedMovieProps } from "./watched-movie";
+import WatchedMovie, { type WatchedMovieProps } from "./watched-movie";
 import { vi } from "vitest";
 import { buildThirdPartyMovieMock } from "../../../../../../test-utils/build-third-party-movie-mock";
 import { within, screen } from "@testing-library/react";

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.tsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.tsx
@@ -1,5 +1,5 @@
 import { format, parseISO } from "date-fns";
-import { useState, useMemo, ReactElement } from "react";
+import { useState, useMemo, type ReactElement } from "react";
 import { useGetThirdPartyFullDetails } from "../../../../../../graphql/queries";
 import DatePicker from "../date-picker/date-picker";
 import MoviePoster from "../../../movie-poster/movie-poster";
@@ -14,8 +14,8 @@ import {
   Content,
 } from "./watched-movie.styles";
 import { useMediaQuery } from "@mui/material";
-import { SpringValues, useSpring } from "react-spring";
-import { Movie } from "../../../../../../__generated__/graphql";
+import { type SpringValues, useSpring } from "react-spring";
+import { type Movie } from "../../../../../../__generated__/graphql";
 
 export type WatchedMovieProps = {
   movie: Movie;

--- a/packages/web/src/components/app/components/watched/components/watched-toolbar/watched-toolbar.test.tsx
+++ b/packages/web/src/components/app/components/watched/components/watched-toolbar/watched-toolbar.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import WatchedToolbar, { WatchedToolbarProps } from "./watched-toolbar";
+import WatchedToolbar, { type WatchedToolbarProps } from "./watched-toolbar";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../test-utils/render-with-providers";
 

--- a/packages/web/src/components/app/components/watched/components/watched-toolbar/watched-toolbar.tsx
+++ b/packages/web/src/components/app/components/watched/components/watched-toolbar/watched-toolbar.tsx
@@ -7,7 +7,7 @@ import {
 import Close from "@mui/icons-material/Close";
 import Search from "@mui/icons-material/Search";
 import { Layout, Status } from "./watched-toolbar.styles";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 export type WatchedToolbarProps = {

--- a/packages/web/src/components/app/components/watched/watched.error.test.tsx
+++ b/packages/web/src/components/app/components/watched/watched.error.test.tsx
@@ -5,13 +5,13 @@ import { vi } from "vitest";
 import { GET_WATCHED_MOVIES } from "../../../../graphql/queries/get-watched-movies";
 import { REMOVE_MOVIE } from "../../../../graphql/mutations";
 import { buildMovieMock } from "../../../../test-utils/build-movie-mock";
-import { WatchedMovieProps } from "./components/watched-movie/watched-movie";
-import { MockedResponse } from "@apollo/client/testing";
+import { type WatchedMovieProps } from "./components/watched-movie/watched-movie";
+import { type MockedResponse } from "@apollo/client/testing";
 import {
-  GetWatchedMoviesQuery,
-  GetWatchedMoviesQueryVariables,
-  RemoveMovieMutation,
-  RemoveMovieMutationVariables,
+  type GetWatchedMoviesQuery,
+  type GetWatchedMoviesQueryVariables,
+  type RemoveMovieMutation,
+  type RemoveMovieMutationVariables,
 } from "../../../../__generated__/graphql";
 
 vi.mock("./components/watched-movie/watched-movie", () => ({

--- a/packages/web/src/components/app/components/watched/watched.test.tsx
+++ b/packages/web/src/components/app/components/watched/watched.test.tsx
@@ -4,11 +4,11 @@ import { renderWithProviders } from "../../../../test-utils/render-with-provider
 import { vi } from "vitest";
 import { GET_WATCHED_MOVIES } from "../../../../graphql/queries/get-watched-movies";
 import { buildMovieMock } from "../../../../test-utils/build-movie-mock";
-import { WatchedMovieProps } from "./components/watched-movie/watched-movie";
-import { MockedResponse } from "@apollo/client/testing";
+import { type WatchedMovieProps } from "./components/watched-movie/watched-movie";
+import { type MockedResponse } from "@apollo/client/testing";
 import {
-  GetWatchedMoviesQuery,
-  GetWatchedMoviesQueryVariables,
+  type GetWatchedMoviesQuery,
+  type GetWatchedMoviesQueryVariables,
 } from "../../../../__generated__/graphql";
 
 vi.mock("./components/watched-movie/watched-movie", () => ({

--- a/packages/web/src/components/app/components/watched/watched.tsx
+++ b/packages/web/src/components/app/components/watched/watched.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import isNil from "lodash/isNil";
 
 import { StackedContainer, NoMoviesFound } from "./watched.styles";
@@ -17,7 +17,7 @@ import { SortDirection } from "../../../../constants/sorts";
 import WatchedToolbar from "./components/watched-toolbar/watched-toolbar";
 import MovieRemove from "mdi-material-ui/MovieRemove";
 import { useGetWatchedMovies } from "../../../../graphql/queries";
-import { Movie } from "../../../../__generated__/graphql";
+import { type Movie } from "../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
 
 const INFINITE_LOAD_CHUNK_SIZE = 5;

--- a/packages/web/src/components/authenticated-apollo-provider/authenticated-apollo-provider.tsx
+++ b/packages/web/src/components/authenticated-apollo-provider/authenticated-apollo-provider.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren, ReactElement, useEffect, useState } from "react";
+import { type PropsWithChildren, type ReactElement, useEffect, useState } from "react";
 import {
   ApolloClient,
   ApolloProvider,
   HttpLink,
   InMemoryCache,
-  NormalizedCacheObject,
+  type NormalizedCacheObject,
   from,
 } from "@apollo/client";
 import { removeTypenameFromVariables } from "@apollo/client/link/remove-typename";

--- a/packages/web/src/components/error-boundary/error-boundary.tsx
+++ b/packages/web/src/components/error-boundary/error-boundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ErrorInfo, ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface Props {
   children?: ReactNode;

--- a/packages/web/src/context/app-context.tsx
+++ b/packages/web/src/context/app-context.tsx
@@ -1,9 +1,9 @@
-import React, { PropsWithChildren, ReactElement, useCallback } from "react";
+import React, { type PropsWithChildren, type ReactElement, useCallback } from "react";
 import { createContext, useState } from "react";
 import { useGetLists, useGetMovies } from "../graphql/queries";
-import { GetListsItem, GetMovieItem } from "../graphql/types";
-import { Maybe } from "graphql/jsutils/Maybe";
-import { ToastProps } from "../types";
+import { type GetListsItem, type GetMovieItem } from "../graphql/types";
+import { type Maybe } from "graphql/jsutils/Maybe";
+import { type ToastProps } from "../types";
 
 export type AppContextType = {
   lists: GetListsItem[];

--- a/packages/web/src/graphql/mutations/add-list.ts
+++ b/packages/web/src/graphql/mutations/add-list.ts
@@ -1,9 +1,9 @@
-import { BaseMutationOptions, MutationTuple, gql } from "@apollo/client";
+import { type BaseMutationOptions, type MutationTuple, gql } from "@apollo/client";
 import { useMutation } from "@apollo/client";
 import { GET_LISTS } from "../queries";
 import {
-  AddListMutation,
-  AddListMutationVariables,
+  type AddListMutation,
+  type AddListMutationVariables,
 } from "../../__generated__/graphql";
 
 const ADD_LIST = gql`

--- a/packages/web/src/graphql/mutations/add-movie.ts
+++ b/packages/web/src/graphql/mutations/add-movie.ts
@@ -1,6 +1,6 @@
 import {
-  BaseMutationOptions,
-  MutationTuple,
+  type BaseMutationOptions,
+  type MutationTuple,
   gql,
   useMutation,
 } from "@apollo/client";
@@ -8,11 +8,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import { GET_MOVIES } from "../queries";
 import {
-  AddMovieMutation,
-  AddMovieMutationVariables,
-  MovieInput,
+  type AddMovieMutation,
+  type AddMovieMutationVariables,
+  type MovieInput,
 } from "../../__generated__/graphql";
-import { GetListsItem, NewMovieInput } from "../types";
+import { type GetListsItem, type NewMovieInput } from "../types";
 
 export const ADD_MOVIE = gql`
   mutation AddMovie($movie: MovieInput!, $list: String!) {

--- a/packages/web/src/graphql/mutations/edit-movie.ts
+++ b/packages/web/src/graphql/mutations/edit-movie.ts
@@ -1,15 +1,15 @@
 import {
-  BaseMutationOptions,
-  MutationTuple,
+  type BaseMutationOptions,
+  type MutationTuple,
   gql,
   useMutation,
 } from "@apollo/client";
 import {
-  EditMovieMutation,
-  EditMovieMutationVariables,
-  Movie,
+  type EditMovieMutation,
+  type EditMovieMutationVariables,
+  type Movie,
 } from "../../__generated__/graphql";
-import { GetListsItem } from "../types";
+import { type GetListsItem } from "../types";
 
 export const EDIT_MOVIE = gql`
   mutation EditMovie(

--- a/packages/web/src/graphql/mutations/mark-watched.ts
+++ b/packages/web/src/graphql/mutations/mark-watched.ts
@@ -1,17 +1,17 @@
 import {
-  BaseMutationOptions,
-  MutationTuple,
+  type BaseMutationOptions,
+  type MutationTuple,
   gql,
   useMutation,
 } from "@apollo/client";
 import { GET_MOVIES } from "../queries";
 import { GET_WATCHED_MOVIES } from "../queries/get-watched-movies";
 import {
-  MarkWatchedMutation,
-  MarkWatchedMutationVariables,
-  Movie,
+  type MarkWatchedMutation,
+  type MarkWatchedMutationVariables,
+  type Movie,
 } from "../../__generated__/graphql";
-import { GetListsItem } from "../types";
+import { type GetListsItem } from "../types";
 
 export const MARK_WATCHED = gql`
   mutation MarkWatched($movie: MovieInput!, $list: String!) {

--- a/packages/web/src/graphql/mutations/remove-movie.ts
+++ b/packages/web/src/graphql/mutations/remove-movie.ts
@@ -1,14 +1,14 @@
 import {
-  BaseMutationOptions,
-  MutationTuple,
+  type BaseMutationOptions,
+  type MutationTuple,
   gql,
   useMutation,
 } from "@apollo/client";
 import { GET_MOVIES, GET_WATCHED_MOVIES } from "../queries";
 import {
-  Movie,
-  RemoveMovieMutation,
-  RemoveMovieMutationVariables,
+  type Movie,
+  type RemoveMovieMutation,
+  type RemoveMovieMutationVariables,
 } from "../../__generated__/graphql";
 
 export const REMOVE_MOVIE = gql`

--- a/packages/web/src/graphql/mutations/undo-mark-watched.ts
+++ b/packages/web/src/graphql/mutations/undo-mark-watched.ts
@@ -1,16 +1,16 @@
 import {
-  BaseMutationOptions,
-  MutationTuple,
+  type BaseMutationOptions,
+  type MutationTuple,
   gql,
   useMutation,
 } from "@apollo/client";
 import { GET_WATCHED_MOVIES } from "../queries/get-watched-movies";
 import {
-  Movie,
-  UndoMarkWatchedMutation,
-  UndoMarkWatchedMutationVariables,
+  type Movie,
+  type UndoMarkWatchedMutation,
+  type UndoMarkWatchedMutationVariables,
 } from "../../__generated__/graphql";
-import { GetListsItem } from "../types";
+import { type GetListsItem } from "../types";
 
 const UNDO_MARK_WATCHED = gql`
   mutation UndoMarkWatched(

--- a/packages/web/src/graphql/mutations/update-movie.ts
+++ b/packages/web/src/graphql/mutations/update-movie.ts
@@ -2,9 +2,9 @@ import { gql, useMutation } from "@apollo/client";
 import { isToday, isValid, parseISO } from "date-fns";
 import { useEffect } from "react";
 import {
-  Movie,
-  UpdateMovieMutation,
-  UpdateMovieMutationVariables,
+  type Movie,
+  type UpdateMovieMutation,
+  type UpdateMovieMutationVariables,
 } from "../../__generated__/graphql";
 
 export const UPDATE_MOVIE = gql`

--- a/packages/web/src/graphql/queries/get-lists.ts
+++ b/packages/web/src/graphql/queries/get-lists.ts
@@ -1,6 +1,6 @@
-import { QueryResult, gql, useQuery } from "@apollo/client";
-import { GetListsQuery } from "../../__generated__/graphql";
-import { GetListsItem } from "../types";
+import { type QueryResult, gql, useQuery } from "@apollo/client";
+import { type GetListsQuery } from "../../__generated__/graphql";
+import { type GetListsItem } from "../types";
 import { notEmpty } from "../../utils/not-empty";
 
 export const GET_LISTS = gql`

--- a/packages/web/src/graphql/queries/get-movies.ts
+++ b/packages/web/src/graphql/queries/get-movies.ts
@@ -1,6 +1,6 @@
-import { QueryResult, gql, useQuery } from "@apollo/client";
-import { GetMovieItem, GetListsItem } from "../types";
-import { GetMoviesQuery } from "../../__generated__/graphql";
+import { type QueryResult, gql, useQuery } from "@apollo/client";
+import { type GetMovieItem, type GetListsItem } from "../types";
+import { type GetMoviesQuery } from "../../__generated__/graphql";
 import { notEmpty } from "../../utils/not-empty";
 
 export const GET_MOVIES = gql`

--- a/packages/web/src/graphql/queries/get-third-party-movie-full-details.ts
+++ b/packages/web/src/graphql/queries/get-third-party-movie-full-details.ts
@@ -1,8 +1,8 @@
 import { gql, useQuery } from "@apollo/client";
 import {
-  GetThirdPartyMovieFullDetailsQuery,
-  GetThirdPartyMovieFullDetailsQueryVariables,
-  Maybe,
+  type GetThirdPartyMovieFullDetailsQuery,
+  type GetThirdPartyMovieFullDetailsQueryVariables,
+  type Maybe,
 } from "../../__generated__/graphql";
 
 export const GET_THIRD_PARTY_MOVIE_FULL_DETAILS = gql`

--- a/packages/web/src/graphql/queries/get-watched-movies.ts
+++ b/packages/web/src/graphql/queries/get-watched-movies.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
-import { GetListsItem } from "../types";
-import { GetWatchedMoviesQuery, Maybe } from "../../__generated__/graphql";
+import { type GetListsItem } from "../types";
+import { type GetWatchedMoviesQuery, type Maybe } from "../../__generated__/graphql";
 import { notEmpty } from "../../utils/not-empty";
 
 export const GET_WATCHED_MOVIES = gql`

--- a/packages/web/src/graphql/queries/search-by-title.ts
+++ b/packages/web/src/graphql/queries/search-by-title.ts
@@ -1,9 +1,9 @@
 import { gql, useLazyQuery } from "@apollo/client";
 import {
-  SearchByTitleQuery,
-  SearchByTitleQueryVariables,
+  type SearchByTitleQuery,
+  type SearchByTitleQueryVariables,
 } from "../../__generated__/graphql";
-import { Maybe } from "graphql/jsutils/Maybe";
+import { type Maybe } from "graphql/jsutils/Maybe";
 
 export const SEARCH_BY_TITLE = gql`
   query SearchByTitle($title: String!, $year: String, $page: Int) {

--- a/packages/web/src/graphql/types/index.ts
+++ b/packages/web/src/graphql/types/index.ts
@@ -1,10 +1,10 @@
 import {
-  GetListsQuery,
-  GetMoviesQuery,
-  Movie,
-  MovieInput,
+  type GetListsQuery,
+  type GetMoviesQuery,
+  type Movie,
+  type MovieInput,
 } from "../../__generated__/graphql";
-import { ArrayElement } from "../utils";
+import { type ArrayElement } from "../utils";
 
 export type GetListsItem = NonNullable<
   ArrayElement<NonNullable<GetListsQuery["lists"]>>

--- a/packages/web/src/i18next/i18n.d.ts
+++ b/packages/web/src/i18next/i18n.d.ts
@@ -1,4 +1,4 @@
-import Resources from "../__generated__/resources";
+import type Resources from "../__generated__/resources";
 
 declare module "i18next" {
   interface CustomTypeOptions {

--- a/packages/web/src/i18next/i18next-config.ts
+++ b/packages/web/src/i18next/i18next-config.ts
@@ -2,7 +2,7 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import ICU from "i18next-icu";
 import resources from "../__generated__/resources";
-import { TFunction } from "i18next";
+import { type TFunction } from "i18next";
 
 // This function initializes the i18next instance.
 // It is used by the main.jsx for the app in the browser and also by the vite-setup.js to setup i18n for the test environment.

--- a/packages/web/src/test-utils/build-movie-mock.ts
+++ b/packages/web/src/test-utils/build-movie-mock.ts
@@ -1,5 +1,5 @@
-import { Movie } from "../__generated__/graphql";
-import { GetMovieItem } from "../graphql/types";
+import { type Movie } from "../__generated__/graphql";
+import { type GetMovieItem } from "../graphql/types";
 
 export const buildMovieMock = (
   mockData: Partial<Movie> = {}

--- a/packages/web/src/test-utils/build-third-party-movie-mock.ts
+++ b/packages/web/src/test-utils/build-third-party-movie-mock.ts
@@ -1,4 +1,4 @@
-import { ThirdPartyMovie } from "../__generated__/graphql";
+import { type ThirdPartyMovie } from "../__generated__/graphql";
 
 export const buildThirdPartyMovieMock = (
   mockData: Partial<ThirdPartyMovie> = {}

--- a/packages/web/src/test-utils/render-with-providers.tsx
+++ b/packages/web/src/test-utils/render-with-providers.tsx
@@ -1,11 +1,11 @@
 import {
-  RenderHookResult,
-  RenderOptions,
-  RenderResult,
+  type RenderHookResult,
+  type RenderOptions,
+  type RenderResult,
   render,
   renderHook,
 } from "@testing-library/react";
-import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { MockedProvider, type MockedResponse } from "@apollo/client/testing";
 import { AppProvider } from "../context/app-context";
 import { GET_LISTS, GET_MOVIES } from "../graphql/queries";
 import { ThemeProvider } from "@mui/material";
@@ -15,12 +15,12 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { buildMovieMock } from "./build-movie-mock";
 import { I18nextProvider } from "react-i18next";
 import i18n from "i18next";
-import { ReactElement } from "react";
+import { type ReactElement } from "react";
 import {
-  GetListsQuery,
-  GetListsQueryVariables,
-  GetMoviesQuery,
-  GetMoviesQueryVariables,
+  type GetListsQuery,
+  type GetListsQueryVariables,
+  type GetMoviesQuery,
+  type GetMoviesQueryVariables,
 } from "../__generated__/graphql";
 import type { User } from "@auth0/auth0-react";
 

--- a/packages/web/src/theme/theme.ts
+++ b/packages/web/src/theme/theme.ts
@@ -1,4 +1,4 @@
-import { Color, PaletteColorOptions, createTheme } from "@mui/material";
+import { type Color, type PaletteColorOptions, createTheme } from "@mui/material";
 import { grey } from "@mui/material/colors";
 
 // Module Augmentation: Extend the interfaces used in the theme

--- a/packages/web/src/utils/filter-movies.test.ts
+++ b/packages/web/src/utils/filter-movies.test.ts
@@ -1,6 +1,6 @@
 import { subDays } from "date-fns";
 import { filterMovies } from "./filter-movies";
-import { Movie } from "../__generated__/graphql";
+import { type Movie } from "../__generated__/graphql";
 
 interface LocalTestContext {
   movie1: Movie;

--- a/packages/web/src/utils/filter-movies.ts
+++ b/packages/web/src/utils/filter-movies.ts
@@ -2,7 +2,7 @@ import filter from "lodash/filter";
 // @ts-expect-error @types for lodash does not have a d.ts for conforms.
 import conforms from "lodash/conforms";
 import { isBefore, parseISO, subDays } from "date-fns";
-import { Movie } from "../__generated__/graphql";
+import { type Movie } from "../__generated__/graphql";
 
 export const filterMovies = (
   movies: Movie[],


### PR DESCRIPTION
Cleans up the eslint configs a bit now that the app is converted to typescript, including adding a config for api. Mostly fixes all the imports that were only for types.