### PR TITLE
#169: fix missing backdrop and add tests

### DIFF
--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.styles.ts
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.styles.ts
@@ -20,14 +20,16 @@ export const BackdropWrapper = styled("div")(() => ({
     "linear-gradient(to bottom, rgba(0, 0, 0, 0.75) 40%, rgba(0,0,0,0.1) 100%)",
 }));
 
-export const Backdrop = styled("div")<{ $imageUrl?: string | null }>(
-  ($imageUrl) => ({
-    backgroundImage: `url(${$imageUrl})`,
-    backgroundPosition: "center 20%",
-    backgroundSize: "cover",
-    height: "100%",
-  })
-);
+interface BackdropProps {
+  $imageUrl?: string | null;
+}
+
+export const Backdrop = styled("div")<BackdropProps>(({ $imageUrl }) => ({
+  backgroundImage: `url(${$imageUrl})`,
+  backgroundPosition: "center 20%",
+  backgroundSize: "cover",
+  height: "100%",
+}));
 
 interface ContentProps {
   $right: boolean;

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.tsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.test.tsx
@@ -73,6 +73,36 @@ describe("watched-movie", () => {
     expect(screen.getByLabelText("Test Movie Poster")).toBeInTheDocument();
   });
 
+  it<LocalTestContext>("should render the backdrop when the movie has a background", async ({
+    props,
+  }) => {
+    renderWithProviders(
+      <WatchedMovie
+        {...props}
+        movie={{ ...props.movie, background: "https://movie_background" }}
+      />,
+      {
+        mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+      }
+    );
+
+    expect(
+      await screen.findByTestId("https://movie_background")
+    ).toBeInTheDocument();
+  });
+
+  it<LocalTestContext>("should render the backdrop when the third party data has a backdrop and the movie does not", async ({
+    props,
+  }) => {
+    renderWithProviders(<WatchedMovie {...props} />, {
+      mocks: [GET_THIRD_PARTY_MOVIE_FULL_DETAILS_MOCK],
+    });
+
+    expect(
+      await screen.findByTestId("http://image.tmdb.org/t/1.jpg")
+    ).toBeInTheDocument();
+  });
+
   it<LocalTestContext>("should render the poster followed by the info when left-aligned", ({
     props,
   }) => {

--- a/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.tsx
+++ b/packages/web/src/components/app/components/watched/components/watched-movie/watched-movie.tsx
@@ -92,7 +92,10 @@ const WatchedMovie = ({
       }}
     >
       <BackdropWrapper>
-        <Backdrop $imageUrl={movie.background || data?.backdrop} />
+        <Backdrop
+          $imageUrl={movie.background || data?.backdrop}
+          data-testid={movie.background || data?.backdrop}
+        />
       </BackdropWrapper>
       <Content $right={right} data-testid="content">
         {right ? nodes.reverse() : nodes}


### PR DESCRIPTION
Fixes a destructuring syntax issue that was causing the backdrop not to be found. Added a couple of tests, which required adding a testid of the background url because a css style can't be tested.