### PR TITLE
#171: change to use img lazy

### DIFF
--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -65,6 +65,7 @@ const Movie = ({
     isTouchInterface ? 0 : 500
   );
   const unfocus = (): void => {
+    console.log("unfocus");
     focus.cancel();
     setFocused(false);
     // This is ugly. Occasionally, posters get stuck in the focused state because they unfocus and then trigger a very fast
@@ -120,71 +121,74 @@ const Movie = ({
           }}
           data-testid="positioner"
         >
-          <MovieDetail style={posterSpring}>
-            <OverflowWrapper>
-              <MoviePoster movie={movie} height={375} variant="zoom" />
+          {focused && (
+            <MovieDetail style={posterSpring}>
+              <OverflowWrapper>
+                <MoviePoster movie={movie} height={375} variant="zoom" />
 
-              <InfoLayout>
-                <StarRatingLayout
-                  onMouseEnter={switchToRatings}
-                  onMouseLeave={(): void => {
-                    switchToRatings.cancel();
-                    setInfoState("actions");
-                  }}
-                  onClick={(e): void => {
-                    // OnClick, toggle the state.
-                    // Works for desktop and mobile but mainly here for mobile.
-                    setInfoState(
-                      infoState === "ratings" ? "actions" : "ratings"
-                    );
-
-                    // This prevents the card from expanding when tapping the stars on mobile to
-                    // display the ratings breakdown.
-                    if (
-                      "ontouchstart" in window ||
-                      navigator.maxTouchPoints > 0
-                    ) {
-                      e.stopPropagation();
-                    }
-                  }}
-                  data-testid="rating"
-                >
-                  <FiveStarRating stars={movie.fiveStarRating} />
-                </StarRatingLayout>
-
-                <InfoRuntime>{formatRuntime(movie.runtime)}</InfoRuntime>
-
-                <InfoFooterLayout style={actionsSpring} data-testid="actions">
-                  <DetailActions
-                    movie={movie}
-                    onEdit={(): void => {
-                      setFocused(false);
-                      onEditMovie(movie);
+                <InfoLayout>
+                  <StarRatingLayout
+                    onMouseEnter={switchToRatings}
+                    onMouseLeave={(): void => {
+                      switchToRatings.cancel();
+                      setInfoState("actions");
                     }}
-                    onMarkWatched={(): void => {
-                      setFocused(false);
-                      onMarkWatched(movie);
-                    }}
-                    onToggleLock={(locked: boolean): void => {
-                      onEditMovie({ ...movie, locked }, false);
-                    }}
-                    onDelete={(): void => {
-                      setFocused(false);
-                      onRemoveMovie(movie);
-                    }}
-                  />
-                </InfoFooterLayout>
+                    onClick={(e): void => {
+                      // OnClick, toggle the state.
+                      // Works for desktop and mobile but mainly here for mobile.
+                      setInfoState(
+                        infoState === "ratings" ? "actions" : "ratings"
+                      );
 
-                <InfoFooterLayout style={ratingsSpring} data-testid="ratings">
-                  <Ratings ratings={movie.ratings} size="sm" dense />
-                </InfoFooterLayout>
+                      // This prevents the card from expanding when tapping the stars on mobile to
+                      // display the ratings breakdown.
+                      if (
+                        "ontouchstart" in window ||
+                        navigator.maxTouchPoints > 0
+                      ) {
+                        e.stopPropagation();
+                      }
+                    }}
+                    data-testid="rating"
+                  >
+                    <FiveStarRating stars={movie.fiveStarRating} />
+                  </StarRatingLayout>
 
-                <SourceLayout>
-                  <Source source={movie.source} />
-                </SourceLayout>
-              </InfoLayout>
-            </OverflowWrapper>
-          </MovieDetail>
+                  <InfoRuntime>{formatRuntime(movie.runtime)}</InfoRuntime>
+
+                  <InfoFooterLayout style={actionsSpring} data-testid="actions">
+                    <DetailActions
+                      movie={movie}
+                      onEdit={(): void => {
+                        setFocused(false);
+                        onEditMovie(movie);
+                      }}
+                      onMarkWatched={(): void => {
+                        setFocused(false);
+                        onMarkWatched(movie);
+                      }}
+                      onToggleLock={(locked: boolean): void => {
+                        console.log("TOGGLE LOCK");
+                        onEditMovie({ ...movie, locked }, false);
+                      }}
+                      onDelete={(): void => {
+                        setFocused(false);
+                        onRemoveMovie(movie);
+                      }}
+                    />
+                  </InfoFooterLayout>
+
+                  <InfoFooterLayout style={ratingsSpring} data-testid="ratings">
+                    <Ratings ratings={movie.ratings} size="sm" dense />
+                  </InfoFooterLayout>
+
+                  <SourceLayout>
+                    <Source source={movie.source} />
+                  </SourceLayout>
+                </InfoLayout>
+              </OverflowWrapper>
+            </MovieDetail>
+          )}
         </MovieDetailPositioner>
       </MovieContainer>
 

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.styles.ts
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.styles.ts
@@ -24,18 +24,15 @@ export const PosterLayout = styled("div")<PosterLayoutProps>(
   })
 );
 
-export const Poster = styled("div")<{
-  $poster?: false | null | string;
+export const Poster = styled("img")<{
   $active: boolean;
-}>(({ $poster, $active }) => ({
+}>(({ $active }) => ({
   gridArea: "poster",
-  backgroundSize: "cover",
-  backgroundPosition: "center",
-  backgroundRepeat: "no-repeat",
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
   overflow: "hidden",
   borderRadius: 4,
-
-  ...($poster && { backgroundImage: `url(${$poster})` }),
 
   ...($active && {
     cursor: "pointer",
@@ -52,11 +49,13 @@ export const Lock = styled(LockIcon)`
   opacity: 0.4;
 `;
 
-export const NoPoster = styled(Poster)<{
+export const NoPoster = styled("div")<{
+  $active: boolean;
   $disableZoom: boolean;
   $shadow: boolean;
-}>(({ $disableZoom, $shadow, theme: { palette } }) => ({
+}>(({ $active, $disableZoom, $shadow, theme: { palette } }) => ({
   gridArea: "poster",
+  borderRadius: 4,
   display: "grid",
   justifyItems: "center",
   alignItems: "center",
@@ -67,6 +66,13 @@ export const NoPoster = styled(Poster)<{
   boxSizing: "border-box",
   border: "1px solid rgba(0,0,0,10%)",
   padding: 12,
+
+  ...($active && {
+    cursor: "pointer",
+    "&:hover": {
+      transform: "scale(1.025)",
+    },
+  }),
 
   ...($disableZoom && {
     gridTemplateRows: "1fr 100px 32px",

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.test.tsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.test.tsx
@@ -2,14 +2,6 @@ import { render, screen } from "@testing-library/react";
 import MoviePoster, { type MoviePosterProps } from "./movie-poster";
 import { vi } from "vitest";
 
-const { MOCK_USE_IN_VIEW_REF } = vi.hoisted(() => ({
-  MOCK_USE_IN_VIEW_REF: vi.fn().mockReturnValue([null, true]),
-}));
-
-vi.mock("rooks/dist/esm/hooks/useInViewRef", () => ({
-  useInViewRef: MOCK_USE_IN_VIEW_REF,
-}));
-
 interface LocalTestContext {
   props: MoviePosterProps;
 }
@@ -40,23 +32,20 @@ describe("movie-poster", () => {
     props,
   }) => {
     render(<MoviePoster {...props} />);
-    expect(screen.getByTestId("poster")).toHaveStyle({
-      "background-image": `url(${props.movie.poster})`,
-    });
+    expect(screen.getByTestId("poster")).toHaveAttribute(
+      "src",
+      props.movie.poster
+    );
     expect(screen.getByText(/Bourne/)).toBeInTheDocument();
   });
 
-  it<LocalTestContext>("should render the placeholder when the poster is not intersecting the viewport", ({
+  it<LocalTestContext>("should not render the poster when a url does not exist in the movie", ({
     props,
   }) => {
-    MOCK_USE_IN_VIEW_REF.mockReturnValueOnce([null, false]);
-
-    render(<MoviePoster {...props} />);
-
-    expect(screen.getByTestId("poster")).toHaveStyle({
-      "background-image": "",
-    });
-    expect(screen.getByText(/Bourne/)).toBeInTheDocument();
+    render(
+      <MoviePoster {...props} movie={{ ...props.movie, poster: undefined }} />
+    );
+    expect(screen.queryByTestId("poster")).not.toBeInTheDocument();
   });
 
   it<LocalTestContext>("should be active when an onClick handler is provided", ({

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.tsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.tsx
@@ -1,6 +1,5 @@
 import { Lock, NoPoster, Poster, PosterLayout } from "./movie-poster.styles";
-import { useInViewRef } from "rooks/dist/esm/hooks/useInViewRef";
-import { type ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import { type Maybe } from "../../../../__generated__/graphql";
 import { useTranslation } from "react-i18next";
 
@@ -29,9 +28,10 @@ const MoviePoster = ({
   shadow = false,
 }: MoviePosterProps): ReactElement => {
   const { t } = useTranslation(["movie_poster"]);
-  const [ref, visible] = useInViewRef();
 
   const isLocked = movie.locked ?? false;
+
+  const [brokenPoster, setBrokenPoster] = useState(false);
 
   return (
     <PosterLayout
@@ -42,7 +42,6 @@ const MoviePoster = ({
         title: movie.title ?? t("movie_poster:no_title"),
       })}
       onClick={onClick}
-      ref={ref}
     >
       {/* Fallback if the poster is missing or a broken link */}
       <NoPoster
@@ -54,11 +53,15 @@ const MoviePoster = ({
         <div>{movie.title ? movie.title : t("movie_poster:no_title")}</div>
       </NoPoster>
 
-      <Poster
-        data-testid="poster"
-        $poster={visible && movie.poster}
-        $active={!!onClick}
-      />
+      {movie.poster && !brokenPoster && (
+        <Poster
+          data-testid="poster"
+          src={movie.poster}
+          loading="lazy"
+          $active={!!onClick}
+          onError={() => setBrokenPoster(true)}
+        />
+      )}
 
       {isLocked && !noLock && <Lock />}
     </PosterLayout>


### PR DESCRIPTION
In my initial tests, I found that using img lazy relies on how the browser determines an img is close enough to the viewport to be loaded. This is making it load more posters than I was with intersection observer. To compare, I took some baseline lighthouse tests with the current version. In those tests I noticed that many extra DOM nodes are also being loaded because of all the invisible hover card states. So this PR also removes those until hover occurs to see if it will cause an issue and to see how it impacts lighthouse.