### PR TITLE
171: Additional lazy img fixes

### DIFF
--- a/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/components/poster-grid-item/poster-grid-item.styles.ts
+++ b/packages/web/src/components/app/components/add/components/tab-panel-search/components/poster-grid/components/poster-grid-item/poster-grid-item.styles.ts
@@ -9,7 +9,7 @@ export const Layout = styled(animated.div)(
     paddingTop: spacing(0.5),
     color: palette.grey[900],
 
-    "& :hover > div": {
+    "&:hover > div:first-child": {
       transform: `translateY(${spacing(-0.5)})`,
       boxShadow: "0px 6px 8px rgba(0, 0, 0, 0.15)",
     },

--- a/packages/web/src/components/app/components/full-detail/full-detail.styles.ts
+++ b/packages/web/src/components/app/components/full-detail/full-detail.styles.ts
@@ -134,6 +134,7 @@ export const Poster = styled(animated.div)`
   height: fit-content;
   box-shadow: 3px 10px 10px rgba(0, 0, 0, 0.1),
     0px 5px 15px 0px rgba(0, 0, 0, 0.1), 0px 1px 20px 0px rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
 
   @media (max-width: 750px) {
     margin-right: 0;

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -98,6 +98,8 @@ const Movie = ({
 
   useUpdateMovie(movie, focused);
 
+  const poster = <MoviePoster movie={movie} height={375} variant="zoom" />;
+
   return (
     <>
       <MovieContainer
@@ -124,7 +126,7 @@ const Movie = ({
           {focused && (
             <MovieDetail style={posterSpring}>
               <OverflowWrapper>
-                <MoviePoster movie={movie} height={375} variant="zoom" />
+                {poster}
 
                 <InfoLayout>
                   <StarRatingLayout

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.styles.ts
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.styles.ts
@@ -51,9 +51,9 @@ export const Lock = styled(LockIcon)`
 
 export const NoPoster = styled("div")<{
   $active: boolean;
-  $disableZoom: boolean;
   $shadow: boolean;
-}>(({ $active, $disableZoom, $shadow, theme: { palette } }) => ({
+  $height: number;
+}>(({ $active, $shadow, $height, theme: { palette } }) => ({
   gridArea: "poster",
   borderRadius: 4,
   display: "grid",
@@ -61,7 +61,7 @@ export const NoPoster = styled("div")<{
   alignItems: "center",
   textAlign: "center",
   color: palette.grey[800],
-  fontSize: "0.9rem",
+  fontSize: `calc(0.9rem * (${$height} / 250))`,
   background: "#f7f7fc",
   boxSizing: "border-box",
   border: "1px solid rgba(0,0,0,10%)",
@@ -72,11 +72,6 @@ export const NoPoster = styled("div")<{
     "&:hover": {
       transform: "scale(1.025)",
     },
-  }),
-
-  ...($disableZoom && {
-    gridTemplateRows: "1fr 100px 32px",
-    fontSize: "1.2rem",
   }),
 
   ...($shadow && {

--- a/packages/web/src/components/app/components/movie-poster/movie-poster.tsx
+++ b/packages/web/src/components/app/components/movie-poster/movie-poster.tsx
@@ -24,7 +24,6 @@ const MoviePoster = ({
   onClick,
   noLock = false,
   noRel = false,
-  variant = "default",
   shadow = false,
 }: MoviePosterProps): ReactElement => {
   const { t } = useTranslation(["movie_poster"]);
@@ -46,9 +45,9 @@ const MoviePoster = ({
       {/* Fallback if the poster is missing or a broken link */}
       <NoPoster
         data-testid="fallback"
-        $disableZoom={variant === "zoom"}
         $shadow={shadow}
         $active={!!onClick}
+        $height={height}
       >
         <div>{movie.title ? movie.title : t("movie_poster:no_title")}</div>
       </NoPoster>


### PR DESCRIPTION
Fixes the hover state on posters in the add dialog. Also makes sure the hovered image poster on the main grid is loaded before its needed to prevent flickering on hover.