### PR TITLE
#171: Additional fixes for lazy img

### DIFF
--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -98,8 +98,6 @@ const Movie = ({
 
   useUpdateMovie(movie, focused);
 
-  const poster = <MoviePoster movie={movie} height={375} variant="zoom" />;
-
   return (
     <>
       <MovieContainer
@@ -126,7 +124,7 @@ const Movie = ({
           {focused && (
             <MovieDetail style={posterSpring}>
               <OverflowWrapper>
-                {poster}
+                <MoviePoster movie={movie} height={375} variant="zoom" />
 
                 <InfoLayout>
                   <StarRatingLayout


### PR DESCRIPTION
Put zoomed movie poster back inside the JSX so the extra DOM elements aren't loading initially. The flickering of the poster on zoom was being caused by the cache being disabled in dev tools.