### PR TITLE
#171: revert to preload the detail poster

### DIFF
--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactElement, useRef, useState } from "react";
+import React, { type ReactElement, useRef, useState, useMemo } from "react";
 import { useSpring } from "react-spring";
 import debounce from "lodash/debounce";
 
@@ -98,7 +98,12 @@ const Movie = ({
 
   useUpdateMovie(movie, focused);
 
-  const poster = <MoviePoster movie={movie} height={375} variant="zoom" />;
+  // This is instantiated here so that its already loaded when the detail is mounted.
+  // Otherwise, it flickers on mobile when it loads the poster image while mounting.
+  const detailPoster = useMemo(
+    () => <MoviePoster movie={movie} height={375} variant="zoom" />,
+    [movie]
+  );
 
   return (
     <>
@@ -126,7 +131,7 @@ const Movie = ({
           {focused && (
             <MovieDetail style={posterSpring}>
               <OverflowWrapper>
-                {poster}
+                {detailPoster}
 
                 <InfoLayout>
                   <StarRatingLayout

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -98,6 +98,8 @@ const Movie = ({
 
   useUpdateMovie(movie, focused);
 
+  const poster = <MoviePoster movie={movie} height={375} variant="zoom" />;
+
   return (
     <>
       <MovieContainer
@@ -124,7 +126,7 @@ const Movie = ({
           {focused && (
             <MovieDetail style={posterSpring}>
               <OverflowWrapper>
-                <MoviePoster movie={movie} height={375} variant="zoom" />
+                {poster}
 
                 <InfoLayout>
                   <StarRatingLayout


### PR DESCRIPTION
The detail poster is still flickering on mobile. Revert the change so its created before being used and memoize it.