### PR TITLE
#171: Keep both posters mounted

### DIFF
--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.tsx
@@ -90,8 +90,8 @@ describe("movie", () => {
   it<LocalTestContext>("should render a movie list entry", ({ props }) => {
     renderWithProviders(<Movie {...props} />);
 
-    // Should be only one of two posters in the dom when not focused.
-    expect(screen.getAllByLabelText(/Bourne.*Poster/)).toHaveLength(1);
+    // Should be two posters in the dom, one for the unhoverd poster and one for the hover detail poster.
+    expect(screen.getAllByLabelText(/Bourne.*Poster/)).toHaveLength(2);
 
     // The larger poster is invisible by default
     expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 });
@@ -124,7 +124,7 @@ describe("movie", () => {
     expect(screen.getByText("68%")).toBeInTheDocument();
     expect(screen.getByLabelText("Netflix")).toBeInTheDocument();
 
-    // Should be two posters in the dom when focused.
+    // Should be two posters in the dom, one for the unhoverd poster and one for the hover detail poster.
     expect(screen.getAllByLabelText(/Bourne.*Poster/)).toHaveLength(2);
   });
 

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactElement, useRef, useState, useMemo } from "react";
+import React, { type ReactElement, useRef, useState } from "react";
 import { useSpring } from "react-spring";
 import debounce from "lodash/debounce";
 
@@ -98,13 +98,6 @@ const Movie = ({
 
   useUpdateMovie(movie, focused);
 
-  // This is instantiated here so that its already loaded when the detail is mounted.
-  // Otherwise, it flickers on mobile when it loads the poster image while mounting.
-  const detailPoster = useMemo(
-    () => <MoviePoster movie={movie} height={375} variant="zoom" />,
-    [movie]
-  );
-
   return (
     <>
       <MovieContainer
@@ -128,11 +121,11 @@ const Movie = ({
           }}
           data-testid="positioner"
         >
-          {focused && (
-            <MovieDetail style={posterSpring}>
-              <OverflowWrapper>
-                {detailPoster}
+          <MovieDetail style={posterSpring}>
+            <OverflowWrapper>
+              <MoviePoster movie={movie} height={375} variant="zoom" />
 
+              {focused && (
                 <InfoLayout>
                   <StarRatingLayout
                     onMouseEnter={switchToRatings}
@@ -175,7 +168,6 @@ const Movie = ({
                         onMarkWatched(movie);
                       }}
                       onToggleLock={(locked: boolean): void => {
-                        console.log("TOGGLE LOCK");
                         onEditMovie({ ...movie, locked }, false);
                       }}
                       onDelete={(): void => {
@@ -193,9 +185,9 @@ const Movie = ({
                     <Source source={movie.source} />
                   </SourceLayout>
                 </InfoLayout>
-              </OverflowWrapper>
-            </MovieDetail>
-          )}
+              )}
+            </OverflowWrapper>
+          </MovieDetail>
         </MovieDetailPositioner>
       </MovieContainer>
 


### PR DESCRIPTION
Poster still flickering on mobile. Try keeping both posters mounted only mounting the bottom section of the card on hover.