### PR TITLE
#171: Revert conditional mounting of hover cards, add source map & noindex

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -12,6 +12,7 @@
     <meta name="apple-mobile-web-app-title" content="MD4K" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="robots" content="noindex" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.test.tsx
@@ -1,14 +1,10 @@
-import { waitFor, screen, fireEvent } from "@testing-library/react";
+import { waitFor, screen } from "@testing-library/react";
 import Movie, { type MovieProps } from "./movie";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../../../../test-utils/render-with-providers";
 import { Globals } from "react-spring";
 import { UPDATE_MOVIE } from "../../../../../../../../graphql/mutations/update-movie";
 import { type FullDetailModalProps } from "../../../../../full-detail-modal/full-detail-modal";
-
-// NOTE: Throughout this test, I'm using fireEvent to click on things after the hover state is focused because using user.click
-// causes the click to propagate up and close the hover/focus state immediately. This is not how it behaves in the browser
-// making it impossible to test the correct functionality.
 
 Globals.assign({
   skipAnimation: true,
@@ -100,7 +96,7 @@ describe("movie", () => {
     expect(screen.getByText("Expanded")).toHaveAttribute("data-open", "false");
   });
 
-  it<LocalTestContext>("should render the vocused movie card", async ({
+  it<LocalTestContext>("should render the focused movie card", async ({
     props,
     user,
   }) => {
@@ -211,10 +207,7 @@ describe("movie", () => {
       transform: "translateX(0px)",
     });
 
-    // Have to use fireEvent here.
-    // If I use user.hover, its causing the listItem to get a mouseLeave event that unfocuses and removes the hovered card state so nothing can be tested.
-    // Not ideal, but in reality, that isn't what happens.
-    fireEvent.mouseOver(screen.getByTestId("rating"));
+    await user.hover(screen.getByTestId("rating"));
 
     await waitFor(() => {
       expect(screen.getByTestId("actions")).not.toHaveStyle({
@@ -225,7 +218,7 @@ describe("movie", () => {
       transform: "translateX(0px)",
     });
 
-    fireEvent.mouseOut(screen.getByTestId("rating"));
+    await user.unhover(screen.getByTestId("rating"));
 
     await waitFor(() => {
       expect(screen.getByTestId("actions")).toHaveStyle({
@@ -248,7 +241,7 @@ describe("movie", () => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(screen.getByLabelText("Edit"));
+    await user.click(screen.getByLabelText("Edit"));
     expect(props.onEditMovie).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
@@ -266,7 +259,7 @@ describe("movie", () => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(screen.getByLabelText("Mark as Watched"));
+    await user.click(screen.getByLabelText("Mark as Watched"));
     expect(props.onMarkWatched).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
@@ -284,7 +277,7 @@ describe("movie", () => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(screen.getByLabelText("Delete"));
+    await user.click(screen.getByLabelText("Delete"));
     expect(props.onRemoveMovie).toHaveBeenCalledWith(props.movie);
     await waitFor(() =>
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 0 })
@@ -302,7 +295,7 @@ describe("movie", () => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(screen.getByLabelText("Lock"));
+    await user.click(screen.getByLabelText("Lock"));
     expect(props.onEditMovie).toHaveBeenCalledWith(
       {
         ...props.movie,
@@ -325,7 +318,7 @@ describe("movie", () => {
       expect(screen.getByTestId("positioner")).toHaveStyle({ opacity: 1 })
     );
 
-    fireEvent.click(screen.getByLabelText("Unlock"));
+    await user.click(screen.getByLabelText("Unlock"));
     expect(props.onEditMovie).toHaveBeenCalledWith(
       {
         ...props.movie,

--- a/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
+++ b/packages/web/src/components/app/components/list/components/list-grid/components/movie/movie.tsx
@@ -125,67 +125,65 @@ const Movie = ({
             <OverflowWrapper>
               <MoviePoster movie={movie} height={375} variant="zoom" />
 
-              {focused && (
-                <InfoLayout>
-                  <StarRatingLayout
-                    onMouseEnter={switchToRatings}
-                    onMouseLeave={(): void => {
-                      switchToRatings.cancel();
-                      setInfoState("actions");
+              <InfoLayout>
+                <StarRatingLayout
+                  onMouseEnter={switchToRatings}
+                  onMouseLeave={(): void => {
+                    switchToRatings.cancel();
+                    setInfoState("actions");
+                  }}
+                  onClick={(e): void => {
+                    // OnClick, toggle the state.
+                    // Works for desktop and mobile but mainly here for mobile.
+                    setInfoState(
+                      infoState === "ratings" ? "actions" : "ratings"
+                    );
+
+                    // This prevents the card from expanding when tapping the stars on mobile to
+                    // display the ratings breakdown.
+                    if (
+                      "ontouchstart" in window ||
+                      navigator.maxTouchPoints > 0
+                    ) {
+                      e.stopPropagation();
+                    }
+                  }}
+                  data-testid="rating"
+                >
+                  <FiveStarRating stars={movie.fiveStarRating} />
+                </StarRatingLayout>
+
+                <InfoRuntime>{formatRuntime(movie.runtime)}</InfoRuntime>
+
+                <InfoFooterLayout style={actionsSpring} data-testid="actions">
+                  <DetailActions
+                    movie={movie}
+                    onEdit={(): void => {
+                      setFocused(false);
+                      onEditMovie(movie);
                     }}
-                    onClick={(e): void => {
-                      // OnClick, toggle the state.
-                      // Works for desktop and mobile but mainly here for mobile.
-                      setInfoState(
-                        infoState === "ratings" ? "actions" : "ratings"
-                      );
-
-                      // This prevents the card from expanding when tapping the stars on mobile to
-                      // display the ratings breakdown.
-                      if (
-                        "ontouchstart" in window ||
-                        navigator.maxTouchPoints > 0
-                      ) {
-                        e.stopPropagation();
-                      }
+                    onMarkWatched={(): void => {
+                      setFocused(false);
+                      onMarkWatched(movie);
                     }}
-                    data-testid="rating"
-                  >
-                    <FiveStarRating stars={movie.fiveStarRating} />
-                  </StarRatingLayout>
+                    onToggleLock={(locked: boolean): void => {
+                      onEditMovie({ ...movie, locked }, false);
+                    }}
+                    onDelete={(): void => {
+                      setFocused(false);
+                      onRemoveMovie(movie);
+                    }}
+                  />
+                </InfoFooterLayout>
 
-                  <InfoRuntime>{formatRuntime(movie.runtime)}</InfoRuntime>
+                <InfoFooterLayout style={ratingsSpring} data-testid="ratings">
+                  <Ratings ratings={movie.ratings} size="sm" dense />
+                </InfoFooterLayout>
 
-                  <InfoFooterLayout style={actionsSpring} data-testid="actions">
-                    <DetailActions
-                      movie={movie}
-                      onEdit={(): void => {
-                        setFocused(false);
-                        onEditMovie(movie);
-                      }}
-                      onMarkWatched={(): void => {
-                        setFocused(false);
-                        onMarkWatched(movie);
-                      }}
-                      onToggleLock={(locked: boolean): void => {
-                        onEditMovie({ ...movie, locked }, false);
-                      }}
-                      onDelete={(): void => {
-                        setFocused(false);
-                        onRemoveMovie(movie);
-                      }}
-                    />
-                  </InfoFooterLayout>
-
-                  <InfoFooterLayout style={ratingsSpring} data-testid="ratings">
-                    <Ratings ratings={movie.ratings} size="sm" dense />
-                  </InfoFooterLayout>
-
-                  <SourceLayout>
-                    <Source source={movie.source} />
-                  </SourceLayout>
-                </InfoLayout>
-              )}
+                <SourceLayout>
+                  <Source source={movie.source} />
+                </SourceLayout>
+              </InfoLayout>
             </OverflowWrapper>
           </MovieDetail>
         </MovieDetailPositioner>

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -4,6 +4,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  build: {
+    sourcemap: true,
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
This removes any conditional mounting of hover card elements. Its just flickering and causing too many small DOM shifts. I'm going to stick with the lazy loaded images for now but I'm going to look at some other solutions to prevent too many movie cards from loading immediately on the main page to try and reduce excessive DOM elements that way. This also adds source maps and a noindex directive to try and fix a couple small lighthouse suggestions.