### PR TITLE
#195: Auth0 token refresh redirect

### DIFF
--- a/packages/web/src/components/app/components/watched/watched.test.tsx
+++ b/packages/web/src/components/app/components/watched/watched.test.tsx
@@ -129,7 +129,7 @@ describe("watched", () => {
 
   it("should render the movies as watched movie items in reverse chronological order", async () => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_WATCHED_MOVIES_MOCK,
+      mocks: [GET_WATCHED_MOVIES_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -154,7 +154,7 @@ describe("watched", () => {
     user,
   }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_WATCHED_MOVIES_MOCK,
+      mocks: [GET_WATCHED_MOVIES_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -177,7 +177,7 @@ describe("watched", () => {
     user,
   }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_WATCHED_MOVIES_MOCK,
+      mocks: [GET_WATCHED_MOVIES_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -211,7 +211,7 @@ describe("watched", () => {
 
   it("should enable editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_WATCHED_MOVIES_MOCK,
+      mocks: [GET_WATCHED_MOVIES_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -227,7 +227,7 @@ describe("watched", () => {
 
   it("should save the movie and disable editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_WATCHED_MOVIES_MOCK,
+      mocks: [GET_WATCHED_MOVIES_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();
@@ -266,7 +266,7 @@ describe("watched", () => {
 
   it("should cancel editing", async ({ user }) => {
     renderWithProviders(<Watched />, {
-      moviesMock: GET_WATCHED_MOVIES_MOCK,
+      mocks: [GET_WATCHED_MOVIES_MOCK],
     });
 
     expect(await screen.findByText(/Bourne/)).toBeInTheDocument();

--- a/packages/web/src/context/app-context.tsx
+++ b/packages/web/src/context/app-context.tsx
@@ -1,4 +1,8 @@
-import React, { type PropsWithChildren, type ReactElement, useCallback } from "react";
+import React, {
+  type PropsWithChildren,
+  type ReactElement,
+  useCallback,
+} from "react";
 import { createContext, useState } from "react";
 import { useGetLists, useGetMovies } from "../graphql/queries";
 import { type GetListsItem, type GetMovieItem } from "../graphql/types";
@@ -39,7 +43,11 @@ const AppContext = createContext<AppContextType>({
 
 const AppProvider = ({ children }: PropsWithChildren): ReactElement => {
   const [list, _setList] = useState<GetListsItem | null>(null);
-  const { lists, loading: listsLoading } = useGetLists({
+  const {
+    lists,
+    loading: listsLoading,
+    error: listsError,
+  } = useGetLists({
     onCompleted: _setList,
   });
 
@@ -49,9 +57,15 @@ const AppProvider = ({ children }: PropsWithChildren): ReactElement => {
     movies,
     moviesById,
     loading: moviesLoading,
+    error: moviesError,
   } = useGetMovies(list ?? lists?.[0]);
   const [toast, setToast] = useState<ToastProps | null>(null);
   const [pick, setPick] = useState<string | null>(null);
+
+  // If we can't get the lists or movies, throw an error. The whole app isn't going to work.
+  // This is almost always an error due to expired auth which is handled in the Apollo client.
+  // But if something else goes wrong, this will show the error screen.
+  if (listsError || moviesError) throw new Error("GraphQL Error at AppContext");
 
   // Expose a list change function so that we can clear any state from the old list while changing to a new one
   const setList = useCallback((list: GetListsItem) => {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -6,13 +6,16 @@ import { App } from "./components/app/app";
 import { ErrorBoundary } from "./components/error-boundary/error-boundary";
 import {
   createBrowserRouter,
+  isRouteErrorResponse,
   Navigate,
   RouterProvider,
+  useRouteError,
 } from "react-router-dom";
 import { sort, SortDirection } from "./constants/sorts";
 import { I18nextProvider } from "react-i18next";
 import i18n from "i18next";
 import { i18nextConfig } from "./i18next/i18next-config";
+import { type ReactNode } from "react";
 
 // Setup the i18next instance
 i18nextConfig();
@@ -21,6 +24,17 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
+    ErrorBoundary: (): ReactNode => {
+      // FIXME: Implement an error screen.
+      const error = useRouteError() as Error;
+
+      return (
+        <div>
+          <div>An error occurred</div>
+          <div>{error.message}</div>
+        </div>
+      );
+    },
     children: [
       {
         index: true,


### PR DESCRIPTION
Redirect to login on token issue. Also add a stub error boundary and throw from app context if primary GQL request fail.