### PR TITLE
api-cors: add liberal cors policy

### DIFF
--- a/packages/api/vercel.json
+++ b/packages/api/vercel.json
@@ -4,5 +4,22 @@
     "api/index.ts": {
       "includeFiles": "**/schema.graphql"
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Credentials", "value": "true" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Adds a very open CORS policy as Vercel is suddenly blocking api requests from the md4k-web subdomain to the md4k-api subdomain. I'll tighten this up once I know this is the right way to fix it.