### PR TITLE
#196: add some additional logging around graph errors

### DIFF
--- a/packages/web/src/components/authenticated-apollo-provider/authenticated-apollo-provider.tsx
+++ b/packages/web/src/components/authenticated-apollo-provider/authenticated-apollo-provider.tsx
@@ -51,6 +51,7 @@ export const AuthenticatedApolloProvider = ({
         let token;
         try {
           token = await getAccessTokenSilently();
+          console.log({ token });
         } catch (error) {
           console.log("Error getting Auth0 access token silently");
         }
@@ -59,6 +60,7 @@ export const AuthenticatedApolloProvider = ({
         // The url to redirect to is configured in main.tsx in the Auth0Provider props.
         // A different URL can be passed here using the options (ex returning the user to the page they were on).
         // For now, I'm just going to push the user back to main page of the app.
+        if (!token) console.error("No Token. Redirect to login.");
         if (!token) await loginWithRedirect();
 
         return {

--- a/packages/web/src/context/app-context.tsx
+++ b/packages/web/src/context/app-context.tsx
@@ -65,7 +65,12 @@ const AppProvider = ({ children }: PropsWithChildren): ReactElement => {
   // If we can't get the lists or movies, throw an error. The whole app isn't going to work.
   // This is almost always an error due to expired auth which is handled in the Apollo client.
   // But if something else goes wrong, this will show the error screen.
-  if (listsError || moviesError) throw new Error("GraphQL Error at AppContext");
+  if (listsError || moviesError) {
+    console.error(listsError ?? moviesError);
+    throw new Error(
+      `GraphQL Error at AppContext.\n${listsError?.message ?? moviesError?.message ?? "Unknown"}.\n\n${listsError ?? moviesError}`
+    );
+  }
 
   // Expose a list change function so that we can clear any state from the old list while changing to a new one
   const setList = useCallback((list: GetListsItem) => {


### PR DESCRIPTION
Adding more logging to try and diagnose some token issues I'm seeing on Vercel, particularly on iOS.