### PR TITLE
Add an ignore for major new version of mongodb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       - dependency-name: "eslint"
         versions: ["9.x"]
       - dependency-name: "eslint-plugin-vitest"
+      - dependency-name: "mongodb"
+        versions: ["5.x", "6.x"]
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
Until I can get mongodb updated, I'm going to ignore major version updates